### PR TITLE
increased ccloudexporter delay to 120 sec to reduce partial data

### DIFF
--- a/ccloud/ccloud-demo/config-template.yml
+++ b/ccloud/ccloud-demo/config-template.yml
@@ -4,7 +4,7 @@ config:
     timeout: 60
   listener: 0.0.0.0:2112
   noTimestamp: false
-  delay: 60
+  delay: 120
   granularity: PT1M
 rules:
   - clusters:

--- a/ccloud/ccloudexporter/config-template.yml
+++ b/ccloud/ccloudexporter/config-template.yml
@@ -4,7 +4,7 @@ config:
     timeout: 60
   listener: 0.0.0.0:2112
   noTimestamp: false
-  delay: 60
+  delay: 120
   granularity: PT1M
 rules:
   - clusters:


### PR DESCRIPTION
with the setting of 60 sec, I have been seeing wildly oscillating graphs for static data (retained bytes), 120 sec smoothes the data out by leaving enough time for all sources to catch up