### PR TITLE
Update the version to confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-…

### DIFF
--- a/connect/connect-cdc-oracle12-source/README.md
+++ b/connect/connect-cdc-oracle12-source/README.md
@@ -4,7 +4,7 @@
 
 Quickly test Oracle CDC Source Connector with Oracle 12.
 
-* **FIXTHIS: connector not released**: unzip `confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-4956344-preview.zip`
+* **FIXTHIS: connector not released**: unzip `confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-864b192-preview.zip`
 * Download Oracle Database 12c Release 2 (12.2.0.1.0) for Linux x86-64 `linuxx64_12201_database.zip`from this [page](https://www.oracle.com/database/technologies/oracle-database-software-downloads.html) and place it in `./linuxx64_12201_database.zip`
 
 Note: Oracle Database Enterprise Edition 12.x and 18c are no longer available for download. The software is available as a media or FTP request for those customers who own a valid Oracle Database product license for any edition. To request access to these releases, follow the instructions in [Oracle Support Document 1071023.1 (Requesting Physical Shipment or Download URL for Software Media)](https://support.oracle.com/epmos/faces/ui/km/DocumentDisplay.jspx?id=1071023.1) from My Oracle Support. 

--- a/connect/connect-cdc-oracle12-source/cdc-oracle12-cdb-table.sh
+++ b/connect/connect-cdc-oracle12-source/cdc-oracle12-cdb-table.sh
@@ -4,9 +4,9 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/../../scripts/utils.sh
 
-if [ ! -d ${DIR}/confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-4956344-preview ]
+if [ ! -d ${DIR}/confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-864b192-preview ]
 then
-     logerror "ERROR: ${DIR}/confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-4956344-preview is missing."
+     logerror "ERROR: ${DIR}/confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-864b192-preview is missing."
      exit 1
 fi
 

--- a/connect/connect-cdc-oracle12-source/cdc-oracle12-pdb-table.sh
+++ b/connect/connect-cdc-oracle12-source/cdc-oracle12-pdb-table.sh
@@ -4,9 +4,9 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/../../scripts/utils.sh
 
-if [ ! -d ${DIR}/confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-4956344-preview ]
+if [ ! -d ${DIR}/confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-864b192-preview ]
 then
-     logerror "ERROR: ${DIR}/confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-4956344-preview is missing."
+     logerror "ERROR: ${DIR}/confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-864b192-preview is missing."
      exit 1
 fi
 

--- a/connect/connect-cdc-oracle12-source/docker-compose.plaintext-cdb-table.yml
+++ b/connect/connect-cdc-oracle12-source/docker-compose.plaintext-cdb-table.yml
@@ -22,6 +22,6 @@ services:
       - schema-registry
       - oracle
     volumes:
-        - ../../connect/connect-cdc-oracle12-source/confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-4956344-preview:/usr/share/confluent-hub-components/confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-4956344-preview
+        - ../../connect/connect-cdc-oracle12-source/confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-864b192-preview:/usr/share/confluent-hub-components/confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-864b192-preview
     environment:
-      CONNECT_PLUGIN_PATH: /usr/share/confluent-hub-components/confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-4956344-preview
+      CONNECT_PLUGIN_PATH: /usr/share/confluent-hub-components/confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-864b192-preview

--- a/connect/connect-cdc-oracle12-source/docker-compose.plaintext-pdb-table.yml
+++ b/connect/connect-cdc-oracle12-source/docker-compose.plaintext-pdb-table.yml
@@ -22,6 +22,6 @@ services:
       - schema-registry
       - oracle
     volumes:
-        - ../../connect/connect-cdc-oracle12-source/confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-4956344-preview:/usr/share/confluent-hub-components/confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-4956344-preview
+        - ../../connect/connect-cdc-oracle12-source/confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-864b192-preview:/usr/share/confluent-hub-components/confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-864b192-preview
     environment:
-      CONNECT_PLUGIN_PATH: /usr/share/confluent-hub-components/confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-4956344-preview
+      CONNECT_PLUGIN_PATH: /usr/share/confluent-hub-components/confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-864b192-preview


### PR DESCRIPTION
…864b192-preview

Update the connector version to confluentinc-kafka-connect-oracle-cdc-1.0.0-rc-864b192-preview which supports one-way and two-way SSL.