### PR TITLE
Added config -l authPriv to snmptrap command

### DIFF
--- a/connect/connect-snmp-source/README.md
+++ b/connect/connect-snmp-source/README.md
@@ -43,7 +43,7 @@ $ curl -X PUT \
 Test with SNMP v3 trap
 
 ```bash
-$ docker exec snmptrap snmptrap -v 3 -c public -u mysecurityname -a MD5 -A myauthpassword -x DES -X myprivacypassword connect:10161 '' 1.3.6.1.4.1.8072.2.3.0.1 1.3.6.1.4.1.8072.2.3.2.1 i 123456
+$ docker exec snmptrap snmptrap -v 3 -c public -u mysecurityname -l authPriv -a MD5 -A myauthpassword -x DES -X myprivacypassword connect:10161 '' 1.3.6.1.4.1.8072.2.3.0.1 1.3.6.1.4.1.8072.2.3.2.1 i 123456
 ```
 
 Verify we have received the data in snmp-kafka-topic topic

--- a/connect/connect-snmp-source/snmp-trap-source.sh
+++ b/connect/connect-snmp-source/snmp-trap-source.sh
@@ -30,7 +30,7 @@ curl -X PUT \
 sleep 10
 
 log "Test with SNMP v3 trap"
-docker exec snmptrap snmptrap -v 3 -c public -u mysecurityname -a MD5 -A myauthpassword -x DES -X myprivacypassword connect:10161 '' 1.3.6.1.4.1.8072.2.3.0.1 1.3.6.1.4.1.8072.2.3.2.1 i 123456
+docker exec snmptrap snmptrap -v 3 -c public -u mysecurityname -l authPriv -a MD5 -A myauthpassword -x DES -X myprivacypassword connect:10161 '' 1.3.6.1.4.1.8072.2.3.0.1 1.3.6.1.4.1.8072.2.3.2.1 i 123456
 
 sleep 5
 


### PR DESCRIPTION
Without setting the security level to authPriv, the default security level may be applied. With default level of NoAuthNoPriv, passing the auth and privacy passwords will not make sense. As the receiving side of traps will not authenticate the trap messages with supplied passwords. Any password will work for such case.

Solution: Setting the security level to authPriv will ensure that the trap messages are accepted only when the auth and privacy passwords match.