### PR TITLE
Enable topic creation by connect worker

### DIFF
--- a/ccloud/environment/docker-compose.yml
+++ b/ccloud/environment/docker-compose.yml
@@ -59,6 +59,8 @@ services:
       # Externalizing Secrets
       CONNECT_CONFIG_PROVIDERS: 'file'
       CONNECT_CONFIG_PROVIDERS_FILE_CLASS: 'org.apache.kafka.common.config.provider.FileConfigProvider'
+      # Enable topic creation by the connect worker (as auto-topic creation is disabled on Confluent Cloud)
+      CONNECT_TOPIC_CREATION_ENABLE: "true"
 
   control-center:
     image: confluentinc/cp-enterprise-control-center:${TAG}


### PR DESCRIPTION
Enabling explicit topic creation by the connect worker to avoid issues with lack of auto-topic creation in Confluent Cloud.