### PR TITLE
Replication from one cluster to many reproducer

### DIFF
--- a/replicator/one-to-many-with-offsets-translation/README.md
+++ b/replicator/one-to-many-with-offsets-translation/README.md
@@ -92,11 +92,6 @@ $ docker container exec -i connect-us bash -c "kafka-console-consumer \
      --group my-consumer-group"
 ```
 
-Consumer with group my-consumer-group reads 10 messages in US cluster, it should start from previous offset
-```bash
-$ docker container exec -i connect-europe bash -c "kafka-console-consumer --bootstrap-server broker-us:9092 --whitelist 'sales_EUROPE' --max-messages 10 --consumer-property interceptor.classes=io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor --consumer-property confluent.monitoring.interceptor.bootstrap.servers=broker-metrics:9092 --consumer-property group.id=my-consumer-group"
-```
-
 Output:
 
 ```log

--- a/replicator/one-to-many-with-offsets-translation/README.md
+++ b/replicator/one-to-many-with-offsets-translation/README.md
@@ -1,0 +1,203 @@
+# One to Many replication with offsets translation
+
+## Objective
+
+Verify how the offsets are translated is when replicating from one source cluster to many destinations.
+In others words, verifying differents instances of replicators are not sharing a state.
+
+## How to run
+
+```
+$ ./start.sh
+```
+
+## Details of what the script is doing
+
+Sending 20 records in Metrics cluster
+
+```bash
+$ seq -f "sale_%g ${RANDOM}" 20 | docker container exec -i connect-europe bash -c "kafka-console-producer --broker-list broker-metrics:9092 --topic sales"
+```
+
+Consumer with group my-consumer-group and the `ConsumerTimestampsInterceptor` interceptor reads 10 messages in Metrics cluster. The interceptor will create the `__consumer_timestamp` topic.
+
+```bash
+$ docker container exec -i connect-europe bash -c "kafka-console-consumer \
+     --bootstrap-server broker-metrics:9092 \
+     --topic 'sales' \
+     --from-beginning \
+     --max-messages 10 \
+     --group my-consumer-group \
+     --consumer-property interceptor.classes=io.confluent.connect.replicator.offsets.ConsumerTimestampsInterceptor \
+     --consumer-property timestamps.topic.replication.factor=1"
+
+```
+
+Replicate from Metrics to Europe and US
+
+```bash
+$ docker container exec connect-europe \
+curl -X PUT \
+     -H "Content-Type: application/json" \
+     --data '{
+          "connector.class":"io.confluent.connect.replicator.ReplicatorSourceConnector",
+          "key.converter": "io.confluent.connect.replicator.util.ByteArrayConverter",
+          "value.converter": "io.confluent.connect.replicator.util.ByteArrayConverter",
+          "header.converter": "io.confluent.connect.replicator.util.ByteArrayConverter",
+          "src.consumer.group.id": "replicate-metrics-to-europe",
+          "src.kafka.bootstrap.servers": "broker-metrics:9092",
+          "dest.kafka.bootstrap.servers": "broker-europe:9092",
+          "confluent.topic.replication.factor": 1,
+          "provenance.header.enable": true,
+          "topic.whitelist": "sales",
+          "offset.timestamps.commit": false,
+          "offset.translator.batch.period.ms": 5000
+          }' \
+     http://localhost:8083/connectors/replicate-metrics-to-europe/config | jq .
+
+$ docker container exec connect-us \
+curl -X PUT \
+     -H "Content-Type: application/json" \
+     --data '{
+          "connector.class":"io.confluent.connect.replicator.ReplicatorSourceConnector",
+          "key.converter": "io.confluent.connect.replicator.util.ByteArrayConverter",
+          "value.converter": "io.confluent.connect.replicator.util.ByteArrayConverter",
+          "header.converter": "io.confluent.connect.replicator.util.ByteArrayConverter",
+          "src.consumer.group.id": "replicate-metrics-to-us",
+          "src.kafka.bootstrap.servers": "broker-metrics:9092",
+          "dest.kafka.bootstrap.servers": "broker-us:9092",
+          "confluent.topic.replication.factor": 1,
+          "provenance.header.enable": true,
+          "topic.whitelist": "sales",
+          "offset.timestamps.commit": false,
+          "offset.translator.batch.period.ms": 5000
+          }' \
+     http://localhost:8083/connectors/replicate-metrics-to-us/config | jq .
+```
+
+Wait for data to be replicated
+
+Consumer with group my-consumer-group on both Europe and US clusters. The consumer starts at offset 10 and reads the 10 last messages.
+```bash
+$ docker container exec -i connect-europe bash -c "kafka-console-consumer \
+     --bootstrap-server broker-europe:9092 \
+     --topic 'sales' \
+     --max-messages 10  \
+     --group my-consumer-group"
+
+$ docker container exec -i connect-us bash -c "kafka-console-consumer \
+     --bootstrap-server broker-us:9092 \
+     --topic 'sales' \
+     --max-messages 10  \
+     --group my-consumer-group"
+```
+
+Consumer with group my-consumer-group reads 10 messages in US cluster, it should start from previous offset
+```bash
+$ docker container exec -i connect-europe bash -c "kafka-console-consumer --bootstrap-server broker-us:9092 --whitelist 'sales_EUROPE' --max-messages 10 --consumer-property interceptor.classes=io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor --consumer-property confluent.monitoring.interceptor.bootstrap.servers=broker-metrics:9092 --consumer-property group.id=my-consumer-group"
+```
+
+Output:
+
+```log
+09:19:21 ℹ️ Sending 20 records in Metrics cluster
+[2021-08-11 07:19:23,554] WARN [Producer clientId=console-producer] Error while fetching metadata with correlation id 1 : {sales=LEADER_NOT_AVAILABLE} (org.apache.kafka.clients.NetworkClient)
+09:19:24 ℹ️ Consumer with group my-consumer-group reads 10 messages in Metrics cluster
+[2021-08-11 07:19:25,868] WARN The configuration 'key.deserializer' was supplied but isn't a known config. (org.apache.kafka.clients.admin.AdminClientConfig)
+[2021-08-11 07:19:25,869] WARN The configuration 'value.deserializer' was supplied but isn't a known config. (org.apache.kafka.clients.admin.AdminClientConfig)
+[2021-08-11 07:19:25,869] WARN The configuration 'timestamps.topic.replication.factor' was supplied but isn't a known config. (org.apache.kafka.clients.admin.AdminClientConfig)
+[2021-08-11 07:19:25,869] WARN The configuration 'isolation.level' was supplied but isn't a known config. (org.apache.kafka.clients.admin.AdminClientConfig)
+[2021-08-11 07:19:25,869] WARN The configuration 'group.id' was supplied but isn't a known config. (org.apache.kafka.clients.admin.AdminClientConfig)
+[2021-08-11 07:19:25,869] WARN The configuration 'interceptor.classes' was supplied but isn't a known config. (org.apache.kafka.clients.admin.AdminClientConfig)
+[2021-08-11 07:19:25,869] WARN The configuration 'auto.offset.reset' was supplied but isn't a known config. (org.apache.kafka.clients.admin.AdminClientConfig)
+[2021-08-11 07:19:26,899] WARN The configuration 'key.deserializer' was supplied but isn't a known config. (org.apache.kafka.clients.producer.ProducerConfig)
+[2021-08-11 07:19:26,899] WARN The configuration 'value.deserializer' was supplied but isn't a known config. (org.apache.kafka.clients.producer.ProducerConfig)
+[2021-08-11 07:19:26,899] WARN The configuration 'group.id' was supplied but isn't a known config. (org.apache.kafka.clients.producer.ProducerConfig)
+[2021-08-11 07:19:26,899] WARN The configuration 'timestamps.topic.replication.factor' was supplied but isn't a known config. (org.apache.kafka.clients.producer.ProducerConfig)
+[2021-08-11 07:19:26,899] WARN The configuration 'isolation.level' was supplied but isn't a known config. (org.apache.kafka.clients.producer.ProducerConfig)
+[2021-08-11 07:19:26,899] WARN The configuration 'auto.offset.reset' was supplied but isn't a known config. (org.apache.kafka.clients.producer.ProducerConfig)
+sale_1 6822
+sale_2 6822
+sale_3 6822
+sale_4 6822
+sale_5 6822
+sale_6 6822
+sale_7 6822
+sale_8 6822
+sale_9 6822
+sale_10 6822
+Processed a total of 10 messages
+09:19:30 ℹ️ Replicate from Metrics to Europe
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100  1537  100   751  100   786   4723   4943 --:--:-- --:--:-- --:--:--  9666
+{
+  "name": "replicate-metrics-to-europe",
+  "config": {
+    "connector.class": "io.confluent.connect.replicator.ReplicatorSourceConnector",
+    "key.converter": "io.confluent.connect.replicator.util.ByteArrayConverter",
+    "value.converter": "io.confluent.connect.replicator.util.ByteArrayConverter",
+    "header.converter": "io.confluent.connect.replicator.util.ByteArrayConverter",
+    "src.consumer.group.id": "replicate-metrics-to-us",
+    "src.kafka.bootstrap.servers": "broker-metrics:9092",
+    "dest.kafka.bootstrap.servers": "broker-europe:9092",
+    "confluent.topic.replication.factor": "1",
+    "provenance.header.enable": "true",
+    "topic.whitelist": "sales",
+    "offset.timestamps.commit": "false",
+    "offset.translator.batch.period.ms": "5000",
+    "name": "replicate-metrics-to-europe"
+  },
+  "tasks": [],
+  "type": "source"
+}
+09:19:31 ℹ️ Replicate from Metrics to US
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100  1520  100   739  100   781   4707   4974 --:--:-- --:--:-- --:--:--  9681
+{
+  "name": "replicate-metrics-to-us",
+  "config": {
+    "connector.class": "io.confluent.connect.replicator.ReplicatorSourceConnector",
+    "key.converter": "io.confluent.connect.replicator.util.ByteArrayConverter",
+    "value.converter": "io.confluent.connect.replicator.util.ByteArrayConverter",
+    "header.converter": "io.confluent.connect.replicator.util.ByteArrayConverter",
+    "src.consumer.group.id": "replicate-metrics-to-us",
+    "src.kafka.bootstrap.servers": "broker-metrics:9092",
+    "dest.kafka.bootstrap.servers": "broker-us:9092",
+    "confluent.topic.replication.factor": "1",
+    "provenance.header.enable": "true",
+    "topic.whitelist": "sales",
+    "offset.timestamps.commit": "false",
+    "offset.translator.batch.period.ms": "5000",
+    "name": "replicate-metrics-to-us"
+  },
+  "tasks": [],
+  "type": "source"
+}
+09:19:31 ℹ️ Wait for data to be replicated
+09:20:01 ℹ️ Consumer with group my-consumer-group reads 10 messages in Europe cluster, starting from offset 10
+sale_11 6822
+sale_12 6822
+sale_13 6822
+sale_14 6822
+sale_15 6822
+sale_16 6822
+sale_17 6822
+sale_18 6822
+sale_19 6822
+sale_20 6822
+Processed a total of 10 messages
+09:20:07 ℹ️ Consumer with group my-consumer-group reads 10 messages in US cluster, starting from offset 10
+sale_11 6822
+sale_12 6822
+sale_13 6822
+sale_14 6822
+sale_15 6822
+sale_16 6822
+sale_17 6822
+sale_18 6822
+sale_19 6822
+sale_20 6822
+Processed a total of 10 messages
+```

--- a/replicator/one-to-many-with-offsets-translation/docker-compose.mdc-plaintext.yml
+++ b/replicator/one-to-many-with-offsets-translation/docker-compose.mdc-plaintext.yml
@@ -1,0 +1,6 @@
+---
+version: '3.5'
+services:
+  connect-europe:
+    environment:
+      CLASSPATH: "/usr/share/confluent-hub-components/confluentinc-kafka-connect-replicator/lib/replicator-rest-extension-${TAG_BASE}.jar:/usr/share/confluent-hub-components/confluentinc-kafka-connect-replicator/lib/timestamp-interceptor-${TAG_BASE}.jar::/usr/share/java/monitoring-interceptors/*"

--- a/replicator/one-to-many-with-offsets-translation/start.sh
+++ b/replicator/one-to-many-with-offsets-translation/start.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+source ${DIR}/../../scripts/utils.sh
+
+${DIR}/../../environment/mdc-plaintext/start.sh "${PWD}/docker-compose.mdc-plaintext.yml"
+
+log "Sending 20 records in Metrics cluster"
+seq -f "sale_%g ${RANDOM}" 20 | docker container exec -i connect-europe bash -c "kafka-console-producer --broker-list broker-metrics:9092 --topic sales"
+
+log "Consumer with group my-consumer-group reads 10 messages in Metrics cluster"
+# Points of interest:
+# ConsumerTimestampsInterceptor: ConsumerInterceptor creating the __consumer_timestamps topic and recording the offset-timestamp pair
+# __consumer_timestamps is by default created with RF=3 since we have only one broker, we have to defone timestamps.topic.replication.factor=1
+docker container exec -i connect-europe bash -c "kafka-console-consumer \
+     --bootstrap-server broker-metrics:9092 \
+     --topic sales \
+     --from-beginning \
+     --max-messages 10 \
+     --group my-consumer-group \
+     --consumer-property interceptor.classes=io.confluent.connect.replicator.offsets.ConsumerTimestampsInterceptor \
+     --consumer-property timestamps.topic.replication.factor=1"
+
+# log "Print content of __consumer_timestamps in Metrics cluster after reading 10 messages"
+# #key-> consumerGroup: topic-partition
+# #value-> timestamp:delta
+# docker container exec -i connect-europe bash -c "kafka-console-consumer \
+#      --bootstrap-server broker-metrics:9092 \
+#      --topic __consumer_timestamps \
+#      --from-beginning --max-messages 1  \
+#      --property print.key=true \
+#      --property key.deserializer=io.confluent.connect.replicator.offsets.GroupTopicPartitionDeserializer \
+#      --property value.deserializer=io.confluent.connect.replicator.offsets.TimestampAndDeltaDeserializer"
+
+# Setting up a replication of the sales topic on Metrics to Europe and US (one-to-many replication) with offset transaltions.
+# Points of interest:
+# - "offset.timestamps.commit: false" preventing the replicator to commit their timestamps in __consumer_timestamp too.
+# If not disabled, the US cluster will produce a message into __consuemer_timestamps and the Europe replicator will try to translate this offsets in the destination cluster
+# This feature is meaningful when doing an active-active setup or when you need to failback.
+# - "offset.translator.batch.period.ms": 5000 (Defaut 60000ms/1m). For demo purpose, set this value to 5s.
+log "Replicate from Metrics to Europe"
+docker container exec connect-europe \
+curl -X PUT \
+     -H "Content-Type: application/json" \
+     --data '{
+          "connector.class":"io.confluent.connect.replicator.ReplicatorSourceConnector",
+          "key.converter": "io.confluent.connect.replicator.util.ByteArrayConverter",
+          "value.converter": "io.confluent.connect.replicator.util.ByteArrayConverter",
+          "header.converter": "io.confluent.connect.replicator.util.ByteArrayConverter",
+          "src.consumer.group.id": "replicate-metrics-to-us",
+          "src.kafka.bootstrap.servers": "broker-metrics:9092",
+          "dest.kafka.bootstrap.servers": "broker-europe:9092",
+          "confluent.topic.replication.factor": 1,
+          "provenance.header.enable": true,
+          "topic.whitelist": "sales",
+          "offset.timestamps.commit": false,
+          "offset.translator.batch.period.ms": 5000 
+          }' \
+     http://localhost:8083/connectors/replicate-metrics-to-europe/config | jq .
+
+log "Replicate from Metrics to US"
+docker container exec connect-us \
+curl -X PUT \
+     -H "Content-Type: application/json" \
+     --data '{
+          "connector.class":"io.confluent.connect.replicator.ReplicatorSourceConnector",
+          "key.converter": "io.confluent.connect.replicator.util.ByteArrayConverter",
+          "value.converter": "io.confluent.connect.replicator.util.ByteArrayConverter",
+          "header.converter": "io.confluent.connect.replicator.util.ByteArrayConverter",
+          "src.consumer.group.id": "replicate-metrics-to-us",
+          "src.kafka.bootstrap.servers": "broker-metrics:9092",
+          "dest.kafka.bootstrap.servers": "broker-us:9092",
+          "confluent.topic.replication.factor": 1,
+          "provenance.header.enable": true,
+          "topic.whitelist": "sales",
+          "offset.timestamps.commit": false,
+          "offset.translator.batch.period.ms": 5000
+          }' \
+     http://localhost:8083/connectors/replicate-metrics-to-us/config | jq .
+
+log "Wait for data to be replicated"
+sleep 30
+
+## Checking the offsets on the targets clusters
+# log "On Europe cluster, my-consumer-group is at offset=10 on the topic-partition sales-0"
+# docker container exec -it connect-europe bash -c 'echo "exclude.internal.topics=false" > /tmp/consumer.config && kafka-console-consumer \
+#      --consumer.config /tmp/consumer.config \
+#      --bootstrap-server broker-europe:9092 \
+#      --topic __consumer_offsets \
+#      --from-beginning \
+#      --formatter "kafka.coordinator.group.GroupMetadataManager\$OffsetsMessageFormatter" \
+#      --timeout-ms 30000'
+
+# log "On US cluster, my-consumer-group is at offset=10 on the topic-partition sales-0"
+# docker container exec -it connect-europe bash -c 'echo "exclude.internal.topics=false" > /tmp/consumer.config && kafka-console-consumer \
+#      --consumer.config /tmp/consumer.config \
+#      --bootstrap-server broker-us:9092 \
+#      --topic __consumer_offsets \
+#      --from-beginning \
+#      --formatter "kafka.coordinator.group.GroupMetadataManager\$OffsetsMessageFormatter" \
+#      --timeout-ms 30000'
+
+# On Both cluster the "my-consumer-group" will starts just where it stopped on the metrics cluster.
+log "Consumer with group my-consumer-group reads 10 messages in Europe cluster, starting from offset 10"
+docker container exec -i connect-europe bash -c "kafka-console-consumer \
+     --bootstrap-server broker-europe:9092 \
+     --topic sales \
+     --max-messages 10  \
+     --group my-consumer-group"
+
+log "Consumer with group my-consumer-group reads 10 messages in US cluster, starting from offset 10"
+docker container exec -i connect-us bash -c "kafka-console-consumer \
+     --bootstrap-server broker-us:9092 \
+     --topic sales \
+     --max-messages 10  \
+     --group my-consumer-group"
+
+

--- a/replicator/one-to-many-with-offsets-translation/stop.sh
+++ b/replicator/one-to-many-with-offsets-translation/stop.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+source ${DIR}/../../scripts/utils.sh
+
+stop_all "$DIR"


### PR DESCRIPTION
A reproducer to example how a one-to-many replication works.
The main objective is to explain how `__consumer_timestamps` work and verify there is no shared state between different replicator instances.

Once setup a given consumer group should be able to consume from any destination cluster starting from the last translated offset.