### PR TITLE
Fixing which dir is use to generate the PEM Key pair

### DIFF
--- a/environment/sasl-ssl/start.sh
+++ b/environment/sasl-ssl/start.sh
@@ -49,7 +49,7 @@ fi
 OLDDIR=$PWD
 cd ${OLDDIR}/../../environment/sasl-ssl/security
 log "🔐 Generate keys and certificates used for SSL"
-docker run -u0 --rm -v $PWD:/tmp vdesabou/kafka-docker-playground-connect:${CONNECT_TAG} bash -c "/tmp/certs-create.sh > /dev/null 2>&1 && chown -R $(id -u $USER):$(id -g $USER) /tmp/"
+docker run -u0 --rm -v $DIR:/tmp vdesabou/kafka-docker-playground-connect:${CONNECT_TAG} bash -c "/tmp/certs-create.sh > /dev/null 2>&1 && chown -R $(id -u $USER):$(id -g $USER) /tmp/"
 cd ${OLDDIR}/../../environment/sasl-ssl
 
 ENABLE_DOCKER_COMPOSE_FILE_OVERRIDE=""

--- a/other/rbac-with-azure-ad/start.sh
+++ b/other/rbac-with-azure-ad/start.sh
@@ -39,7 +39,7 @@ fi
 
 # Generating public and private keys for token signing
 log "Generating public and private keys for token signing"
-docker run -v $PWD:/tmp -u0 ${CP_KAFKA_IMAGE}:${TAG} bash -c "mkdir -p /tmp/conf; openssl genrsa -out /tmp/conf/keypair.pem 2048; openssl rsa -in /tmp/conf/keypair.pem -outform PEM -pubout -out /tmp/conf/public.pem && chown -R $(id -u $USER):$(id -g $USER) /tmp/conf"
+docker run -v $DIR:/tmp -u0 ${CP_KAFKA_IMAGE}:${TAG} bash -c "mkdir -p /tmp/conf; openssl genrsa -out /tmp/conf/keypair.pem 2048; openssl rsa -in /tmp/conf/keypair.pem -outform PEM -pubout -out /tmp/conf/public.pem && chown -R $(id -u $USER):$(id -g $USER) /tmp/conf"
 
 # Bring up base cluster and Confluent CLI
 docker-compose -f ../../environment/plaintext/docker-compose.yml -f ../../environment/rbac-sasl-plain/docker-compose.yml -f "${PWD}/docker-compose.rbac-with-azure-ad.yml" up -d zookeeper broker tools openldap


### PR DESCRIPTION
When extending an environment, if `$PWD` is used the `/conf` directory is created in the current direct rather than in the environment director.

Using `$DIR` instead of `$PWD` permits to have a more stable and reproducible configuration. 