### PR TITLE
KRaft external mode

### DIFF
--- a/environment/kraft-external-plaintext/README.md
+++ b/environment/kraft-external-plaintext/README.md
@@ -1,0 +1,28 @@
+# KRAFT (without Zookeeper) PLAINTEXT
+
+KRaft is in early access and should be used in development only. It is not suitable for production.
+
+## Description
+
+This is a deployment with no security:
+
+* 1 broker
+* 1 connect
+* 1 schema-registry
+* 1 ksqldb-server
+* 1 ksqldb-cli
+* 1 control-center
+
+Using ksqlDB using CLI:
+
+```bash
+$ docker exec -i ksqldb-cli ksql http://ksqldb-server:8088
+```
+
+## How to run
+
+Simply run:
+
+```
+$ ./start.sh
+```

--- a/environment/kraft-external-plaintext/docker-compose.yml
+++ b/environment/kraft-external-plaintext/docker-compose.yml
@@ -1,0 +1,52 @@
+---
+version: '3.5'
+services:
+
+  zookeeper:
+    profiles:
+    - zookeeper
+
+  controller:
+    image: ${CP_KAFKA_IMAGE}:${TAG}
+    hostname: controller
+    container_name: controller
+    restart: always
+    ports:
+      - "9093:9093"
+      - "29093:29093"
+      - "20000:20000"
+    environment:
+      KAFKA_JMX_PORT: 20000
+      KAFKA_JMX_HOSTNAME: localhost
+      CLUSTER_ID: xtzWWN4bTjitpL3kfd9s5g
+      KAFKA_PROCESS_ROLES: 'controller'
+      KAFKA_NODE_ID: 1000
+      KAFKA_LISTENERS: CONTROLLER://controller:9093      
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1000@controller:9093'                  
+      KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+      # To avoid confluent.cluster.link.enable cannot be enabled with KRaft brokers at this time
+      KAFKA_CONFLUENT_CLUSTER_LINK_ENABLE: "false"
+      # To avoid confluent.balancer.enable cannot be enabled with KRaft brokers at this time
+      KAFKA_CONFLUENT_BALANCER_ENABLE: "false"
+    volumes:
+      - ../../environment/kraft-external-plaintext/update_run.sh:/tmp/update_run.sh    
+    command: "bash -c 'if [ ! -f /tmp/update_run.sh ]; then echo \"ERROR: Did you forget the update_run.sh file that came with this docker-compose.yml file?\" && exit 1 ; else /tmp/update_run.sh && /etc/confluent/docker/run ; fi'"
+  
+  broker:
+    environment:
+      CLUSTER_ID: xtzWWN4bTjitpL3kfd9s5g
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,BROKER:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_LISTENERS: BROKER://:9092,PLAINTEXT_HOST://:29092
+      KAFKA_ADVERTISED_LISTENERS: BROKER://broker:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_PROCESS_ROLES: 'broker'
+      KAFKA_NODE_ID: 1
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1000@controller:9093'
+      KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+      # To avoid confluent.cluster.link.enable cannot be enabled with KRaft brokers at this time
+      KAFKA_CONFLUENT_CLUSTER_LINK_ENABLE: "false"
+      # To avoid confluent.balancer.enable cannot be enabled with KRaft brokers at this time
+      KAFKA_CONFLUENT_BALANCER_ENABLE: "false"
+    volumes:
+      - ../../environment/kraft-external-plaintext/update_run.sh:/tmp/update_run.sh
+    command: "bash -c 'if [ ! -f /tmp/update_run.sh ]; then echo \"ERROR: Did you forget the update_run.sh file that came with this docker-compose.yml file?\" && exit 1 ; else /tmp/update_run.sh && /etc/confluent/docker/run ; fi'"

--- a/environment/kraft-external-plaintext/start.sh
+++ b/environment/kraft-external-plaintext/start.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+source ${DIR}/../../scripts/utils.sh
+
+if ! version_gt $TAG_BASE "6.1.99"; then
+    logwarn "WARN: KRaft (KIP-500) is available since CP 6.2 only"
+    exit 111
+fi
+
+verify_docker_and_memory
+verify_installed "docker-compose"
+check_docker_compose_version
+
+# https://docs.docker.com/compose/profiles/
+profile_control_center_command=""
+if [ -z "$DISABLE_CONTROL_CENTER" ]
+then
+  profile_control_center_command="--profile control-center"
+else
+  log "🛑 control-center is disabled"
+fi
+
+profile_ksqldb_command=""
+if [ -z "$DISABLE_KSQLDB" ]
+then
+  profile_ksqldb_command="--profile ksqldb"
+else
+  log "🛑 ksqldb is disabled"
+fi
+
+# defined grafana variable and when profile is included/excluded
+profile_grafana_command=""
+if [ -z "$ENABLE_JMX_GRAFANA" ]
+then
+  log "🛑 Grafana is disabled"
+else
+  log "📊 Grafana is enabled"
+  profile_grafana_command="--profile grafana"
+fi
+profile_kcat_command=""
+if [ -z "$ENABLE_KCAT" ]
+then
+  log "🛑 kcat is disabled"
+else
+  log "🧰 kcat is enabled"
+  profile_kcat_command="--profile kcat"
+fi
+
+ENABLE_DOCKER_COMPOSE_FILE_OVERRIDE=""
+DOCKER_COMPOSE_FILE_OVERRIDE=$1
+if [ -f "${DOCKER_COMPOSE_FILE_OVERRIDE}" ]
+then
+  ENABLE_DOCKER_COMPOSE_FILE_OVERRIDE="-f ${DOCKER_COMPOSE_FILE_OVERRIDE}"
+fi
+
+docker-compose -f ../../environment/plaintext/docker-compose.yml -f ../../environment/kraft-external-plaintext/docker-compose.yml ${ENABLE_DOCKER_COMPOSE_FILE_OVERRIDE} build
+docker-compose -f ../../environment/plaintext/docker-compose.yml -f ../../environment/kraft-external-plaintext/docker-compose.yml ${ENABLE_DOCKER_COMPOSE_FILE_OVERRIDE} down -v --remove-orphans
+docker-compose -f ../../environment/plaintext/docker-compose.yml -f ../../environment/kraft-external-plaintext/docker-compose.yml ${ENABLE_DOCKER_COMPOSE_FILE_OVERRIDE} ${profile_control_center_command} ${profile_ksqldb_command} ${profile_grafana_command} ${profile_kcat_command} up -d
+log "📝 To see the actual properties file, use ../../scripts/get-properties.sh <container>"
+command="source ../../scripts/utils.sh && docker-compose -f ../../environment/plaintext/docker-compose.yml -f ../../environment/kraft-plaintext/docker-compose.yml ${ENABLE_DOCKER_COMPOSE_FILE_OVERRIDE} ${profile_control_center_command} ${profile_ksqldb_command} ${profile_grafana_command} ${profile_kcat_command} up -d"
+echo "$command" > /tmp/playground-command
+log "✨ If you modify a docker-compose file and want to re-create the container(s), run ../../scripts/recreate-containers.sh or use this command:"
+log "✨ $command"
+
+if [ "$#" -ne 0 ]
+then
+    shift
+fi
+../../scripts/wait-for-connect-and-controlcenter.sh $@
+
+display_jmx_info

--- a/environment/kraft-external-plaintext/stop.sh
+++ b/environment/kraft-external-plaintext/stop.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+source ${DIR}/../../scripts/utils.sh
+
+DOCKER_COMPOSE_FILE_OVERRIDE=$1
+if [ -f "${DOCKER_COMPOSE_FILE_OVERRIDE}" ]
+then
+  docker-compose -f ../../environment/plaintext/docker-compose.yml -f ${DOCKER_COMPOSE_FILE_OVERRIDE} down -v --remove-orphans
+else
+  docker-compose -f ../../environment/plaintext/docker-compose.yml down -v --remove-orphans
+fi

--- a/environment/kraft-external-plaintext/update_run.sh
+++ b/environment/kraft-external-plaintext/update_run.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+. /etc/confluent/docker/bash-config
+
+# Docker workaround: Remove check for KAFKA_ZOOKEEPER_CONNECT parameter
+sed -i '/KAFKA_ZOOKEEPER_CONNECT/d' /etc/confluent/docker/configure
+
+# Docker workaround: Ignore cub zk-ready
+sed -i 's/cub zk-ready/echo ignore zk-ready/' /etc/confluent/docker/ensure
+
+if [[ $KAFKA_PROCESS_ROLES == "controller" ]]
+then
+  # Docker workaround: Remove check for KAFKA_ADVERTISED_LISTENERS when process.roles=controller
+  sed -i 's/dub ensure KAFKA_ADVERTISED_LISTENERS/echo ignore ensure KAFKA_ADVERTISED_LISTENERS/' /etc/confluent/docker/configure
+fi
+
+# KRaft required step: Format the storage directory with a new cluster ID
+if [[ -z "${CLUSTER_ID-}" ]]
+then
+  export CLUSTER_ID
+  CLUSTER_ID=$(kafka-storage random-uuid)
+fi
+
+echo "kafka-storage format --ignore-formatted --cluster-id $CLUSTER_ID --config /etc/kafka/kafka.properties" >> /etc/confluent/docker/ensure


### PR DESCRIPTION
Currently, the playground proposes an internal mode config (ie. `process.roles=broker,controller`).
This config suits for dev environments but t not for critical ones (just as zookeeper+broker on the same machine was not).

The objective of this PR is to showcase how to implement an external mode configuration.

The main tricks during the implementation were:
* Both broker and controller have to share the same cluster id. The `update_run.sh` script has been updated to either generate a Cluster ID or use one from the environment variables.
* When a node is running as a controller only, the `advertised.listeners` doesn't make sense anymore (https://issues.apache.org/jira/browse/KAFKA-13456)

Feel free to challenge the ports