### PR TITLE
Fixing submodule clone

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "reproduction-models"]
 	path = reproduction-models
-	url = https://github.com/confluentinc/kafka-docker-playground-internal.git
+	url = git@github.com:confluentinc/kafka-docker-playground-internal.git


### PR DESCRIPTION
When reproducing an issue, we cannot clone the submodule due to the fact the URL is using HTTP. Using HTTP, we end up having to use username/password which has been deprecated by github:
https://github.blog/changelog/2021-08-12-git-password-authentication-is-shutting-down/

Did a simple branch where I changed the URL in .gitmodule such that it points to the ssh clone rather than http.