### PR TITLE
Add -u (UTC) to date command to calc TODAY and servicenow.since config

### DIFF
--- a/connect/connect-servicenow-source/servicenow-source.sh
+++ b/connect/connect-servicenow-source/servicenow-source.sh
@@ -57,7 +57,7 @@ fi
 
 ${DIR}/../../environment/plaintext/start.sh "${PWD}/docker-compose.plaintext.yml"
 
-TODAY=$(date '+%Y-%m-%d')
+TODAY=$(date -u '+%Y-%m-%d')
 
 log "Creating ServiceNow Source connector"
 curl -X PUT \


### PR DESCRIPTION
Without the -u, some users in advanced timezones may get tomorrow's date in terms of UTC.  The date needs to be in UTC timezone.

This can result in repeated:

```
[2023-01-15 21:32:45,122] WARN [servicenow-source|task-0] Start time is in the future...task wait 30s before proceeding (io.confluent.connect.servicenow.ServiceNowSourceTask:122)
```