### PR TITLE
Example of Authentication log capture

### DIFF
--- a/other/capture-authentication-logs/README.md
+++ b/other/capture-authentication-logs/README.md
@@ -1,0 +1,51 @@
+# Capture Authentication logs
+
+## Objective
+
+Confluent Audit Logs does not (yet) capture authentication logs.
+Authentication success/failures are collected as JMX bean however if you want to get further details like the incoming IP or userID the current solution is to rely on the logs
+
+This example showcase how to capture the auhentication logs.
+
+## How to run
+
+```
+$ playground run -f start-sasl.plain.sh
+```
+
+## Details of what the script is doing
+
+Broker's `Selector` logger log level is configured to DEBUG
+```
+KAFKA_LOG4J_LOGGERS: "org.apache.kafka.common.network.Selector=DEBUG"
+```
+
+We first produce data with valid credentials
+```
+seq 10 | docker exec -i broker kafka-console-producer --bootstrap-server broker:9092 --topic test-topic --producer.config /tmp/good-credentials-client.properties
+```
+
+The `Selector` generate [DEBUG](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/network/Selector.java#L560) logs formatted like following:
+```
+[2023-05-05 16:05:09,254] DEBUG [SocketServer listenerType=ZK_BROKER, nodeId=1] Successfully authenticated with /127.0.0.1 (org.apache.kafka.common.network.Selector)
+```
+
+We can extract the incoming IP using a regex
+```
+docker logs broker | sed -rn 's/^.*SocketServer.*Successfully authent.*\/([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}).*$/Authentication success from IP: \1/p'
+```
+
+Then, we try to produce records with invalid credenials
+```
+docker exec -i broker kafka-console-producer --bootstrap-server localhost:9092 --topic foo --producer.config /tmp/bad-credentials-client.properties
+```
+
+The `Selector` generate [INFO](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/network/Selector.java#L616) logs formatted like following:
+```
+[2023-05-05 16:05:09,254] INFO [SocketServer listenerType=ZK_BROKER, nodeId=1] Failed authentication with /127.0.0.1 (channelId=127.0.0.1:9098-127.0.0.1:33004-8) (userId=badmin, errorMessage=Authentication failed: Invalid username or password) (org.apache.kafka.common.network.Selector)
+```
+
+We can extract the incoming IP and user ID using a regex
+```
+docker logs broker | sed -rn 's/^.*SocketServer.*Failed authent.*\/([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}).*userId=(.*),.*$/Authentication failed from IP: \1 with userId: \2/p'
+```

--- a/other/capture-authentication-logs/bad-credentials-client.properties
+++ b/other/capture-authentication-logs/bad-credentials-client.properties
@@ -1,0 +1,5 @@
+sasl.mechanism=PLAIN
+security.protocol=SASL_PLAINTEXT
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
+  username="bad-client" \
+  password="bad-seceret";

--- a/other/capture-authentication-logs/docker-compose.sasl-plain.yml
+++ b/other/capture-authentication-logs/docker-compose.sasl-plain.yml
@@ -1,0 +1,10 @@
+---
+version: '3.5'
+services:
+
+  broker:
+    environment:
+      KAFKA_LOG4J_LOGGERS: "org.apache.kafka.common.network.Selector=DEBUG"
+    volumes:
+        - ../../other/capture-authentication-logs/good-credentials-client.properties:/tmp/good-credentials-client.properties
+        - ../../other/capture-authentication-logs/bad-credentials-client.properties:/tmp/bad-credentials-client.properties

--- a/other/capture-authentication-logs/good-credentials-client.properties
+++ b/other/capture-authentication-logs/good-credentials-client.properties
@@ -1,0 +1,5 @@
+sasl.mechanism=PLAIN
+security.protocol=SASL_PLAINTEXT
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
+  username="client" \
+  password="client-secret";

--- a/other/capture-authentication-logs/start-sasl-plain.sh
+++ b/other/capture-authentication-logs/start-sasl-plain.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+source ${DIR}/../../scripts/utils.sh
+
+${DIR}/../../environment/sasl-plain/start.sh "${PWD}/docker-compose.sasl-plain.yml"
+
+sleep 10
+
+seq 10 | docker exec -i broker kafka-console-producer --bootstrap-server broker:9092 --topic test-topic --producer.config /tmp/good-credentials-client.properties
+# docker logs broker | grep -E "SocketServer.*Successfully authent.*"
+docker logs broker | sed -rn 's/^.*SocketServer.*Successfully authent.*\/([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}).*$/Authentication success from IP: \1/p'
+
+docker exec -i broker kafka-console-producer --bootstrap-server localhost:9092 --topic foo --producer.config /tmp/bad-credentials-client.properties &
+console_producer_pid=$!
+sleep 10
+kill -9 $console_producer_pid
+sleep 5
+
+#docker logs broker | grep -E "SocketServer.*Failed authent.*userId=(bad-client).*"
+docker logs broker | sed -rn 's/^.*SocketServer.*Failed authent.*\/([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}).*userId=(.*),.*$/Authentication failed from IP: \1 with userId: \2/p'
+

--- a/other/capture-authentication-logs/stop.sh
+++ b/other/capture-authentication-logs/stop.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+source ${DIR}/../../scripts/utils.sh
+
+stop_all "$DIR"


### PR DESCRIPTION
Authentication events are not captured as part of Confluent's Audit log.
If one wants to have authentication details the unique way is to rely on the logs.

This example showcase how to change the log level and which log pattern to grep.