### PR TITLE
Update gcp-spanner-sink make the resource names unique per run 

### DIFF
--- a/connect/connect-gcp-spanner-sink/gcp-spanner-sink.sh
+++ b/connect/connect-gcp-spanner-sink/gcp-spanner-sink.sh
@@ -17,8 +17,11 @@ then
      exit 111
 fi
 
-GCP_SPANNER_INSTANCE="spanner-instance-$USER"
-GCP_SPANNER_DATABASE="spanner-db-$USER"
+# generate an 8-character random suffix to make the resource names unique per run
+UNIQUE_SUFFIX=$(uuidgen | cut -c1-8)
+
+GCP_SPANNER_INSTANCE="spanner-instance-$USER-$UNIQUE_SUFFIX"
+GCP_SPANNER_DATABASE="spanner-db-$USER-$UNIQUE_SUFFIX"
 GCP_SPANNER_REGION=${1:-europe-west2}
 
 cd ../../connect/connect-gcp-spanner-sink


### PR DESCRIPTION
generate an 8-character random suffix to make the resource names unique per run