### PR TITLE
Add commitRecord API assertion to Azure Service Bus Source tests

### DIFF
--- a/ccloud/fm-azure-service-bus-source/fully-managed-azure-service-bus-source.sh
+++ b/ccloud/fm-azure-service-bus-source/fully-managed-azure-service-bus-source.sh
@@ -118,5 +118,20 @@ sleep 180
 log "Verifying topic servicebus-topic"
 playground topic consume --topic servicebus-topic --min-expected-messages 5 --timeout 60
 
+log "Asserting that Azure Service Bus queue is empty after connector processing"
+QUEUE_MESSAGE_COUNT=$(az servicebus queue show \
+    --resource-group $AZURE_RESOURCE_GROUP \
+    --namespace-name $AZURE_SERVICE_BUS_NAMESPACE \
+    --name $AZURE_SERVICE_BUS_QUEUE_NAME \
+    --query "messageCount" -o tsv)
+log "Queue message count: $QUEUE_MESSAGE_COUNT"
+
+if [ "$QUEUE_MESSAGE_COUNT" -eq 0 ]; then
+    log "✅ SUCCESS: Azure Service Bus queue is empty - commitRecord API working correctly"
+else
+    log "❌ FAILURE: $QUEUE_MESSAGE_COUNT messages still remain in Azure Service Bus queue"
+    exit 1
+fi
+
 # {"deliveryCount":{"long":1},"enqueuedTimeUtc":{"long":1672745480672},"contentType":null,"label":null,"correlationId":null,"messageProperties":{"string":"{}"},"partitionKey":null,"replyTo":null,"replyToSessionId":null,"deadLetterSource":null,"timeToLive":{"long":-1},"lockedUntilUtc":{"long":1672745540687},"sequenceNumber":{"long":1},"sessionId":null,"lockToken":{"string":"33067f1f-955e-4739-bcef-6e817f09c18d"},"messageBody":{"bytes":"tets"},"getTo":null}
 # {"deliveryCount":{"long":1},"enqueuedTimeUtc":{"long":1672745518954},"contentType":{"string":"application/json"},"label":null,"correlationId":null,"messageProperties":{"string":"{}"},"partitionKey":null,"replyTo":null,"replyToSessionId":null,"deadLetterSource":null,"timeToLive":{"long":-1},"lockedUntilUtc":{"long":1672745578985},"sequenceNumber":{"long":2},"sessionId":null,"lockToken":{"string":"27e486c4-d167-4720-abfb-d47bd2553776"},"messageBody":{"bytes":"{\"schema\":{\"type\":\"struct\",\"fields\":[{\"type\":\"int32\",\"optional\":false,\"field\":\"id\"},{\"type\":\"string\",\"optional\":false,\"field\":\"first_name\"},{\"type\":\"string\",\"optional\":false,\"field\":\"last_name\"},{\"type\":\"string\",\"optional\":false,\"field\":\"email\"}],\"optional\":false,\"name\":\"server1.dbo.customers.Value\"},\"payload\":{\"id\":1001,\"first_name\":\"Sally\",\"last_name\":\"Thomas\",\"email\":\"sally.thomas@acme.com\"}}"},"getTo":null}

--- a/connect/connect-azure-service-bus-source/azure-service-bus-source.sh
+++ b/connect/connect-azure-service-bus-source/azure-service-bus-source.sh
@@ -114,3 +114,18 @@ sleep 180
 
 log "Verifying topic servicebus-topic"
 playground topic consume --topic servicebus-topic --min-expected-messages 5 --timeout 60
+
+log "Asserting that Azure Service Bus queue is empty after connector processing"
+QUEUE_MESSAGE_COUNT=$(az servicebus queue show \
+    --resource-group $AZURE_RESOURCE_GROUP \
+    --namespace-name $AZURE_SERVICE_BUS_NAMESPACE \
+    --name $AZURE_SERVICE_BUS_QUEUE_NAME \
+    --query "messageCount" -o tsv)
+log "Queue message count: $QUEUE_MESSAGE_COUNT"
+
+if [ "$QUEUE_MESSAGE_COUNT" -eq 0 ]; then
+    log "✅ SUCCESS: Azure Service Bus queue is empty - commitRecord API working correctly"
+else
+    log "❌ FAILURE: $QUEUE_MESSAGE_COUNT messages still remain in Azure Service Bus queue"
+    exit 1
+fi


### PR DESCRIPTION
- Add assertion to verify Azure Service Bus queue is empty after connector processing
- Tests that commitRecord API properly deletes messages from external system
- Applied to both regular connect and fully managed (ccloud) versions

```
with 1.3.2 version of azure service bus
11:15:04 ℹ️ Asserting that Azure Service Bus queue is empty after connector processing
11:15:06 ℹ️ Queue message count: 0
11:15:06 ℹ️ ✅ SUCCESS: Azure Service Bus queue is empty - commitRecord API working correctly
11:15:06 ℹ️ Deleting resource group pgaff48ff92e9c430a90ac85
Continue (y/n)?y
11:15:14 ℹ️ ####################################################
11:15:14 ℹ️ ✅ RESULT: SUCCESS for azure-service-bus-source.sh (took: 9min 3sec - )
11:15:14 ℹ️ ####################################################
```

```
With 1.3.1 version of azure service bus
11:25:09 ℹ️ Asserting that Azure Service Bus queue is empty after connector processing
11:25:11 ℹ️ Queue message count: 10
11:25:11 ℹ️ ❌ FAILURE: 10 messages still remain in Azure Service Bus queue
11:25:11 ℹ️ Deleting resource group pgaff48ff92e9c430a90ac85
Continue (y/n)?y
11:25:20 🔥 ####################################################
11:25:20 🔥 🔥 RESULT: FAILURE for azure-service-bus-source.sh (took: 7min 37sec - )
11:25:20 🔥 ####################################################
```