### PR TITLE
Add commitRecord API assertion to JMS Weblogic Source test

### DIFF
--- a/connect/connect-jms-weblogic-source/docker-compose.plaintext.yml
+++ b/connect/connect-jms-weblogic-source/docker-compose.plaintext.yml
@@ -17,10 +17,17 @@ services:
     container_name: weblogic-jms
     ports:
       - '7001:7001'
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7001/weblogic/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
 
   connect:
     depends_on:
-      - weblogic-jms
+      weblogic-jms:
+        condition: service_healthy
     volumes:
         - ../../connect/connect-jms-weblogic-source/jms-sender/lib/wlthint3client.jar:/usr/share/confluent-hub-components/confluentinc-kafka-connect-jms/lib/wlthint3client.jar
     environment:

--- a/connect/connect-jms-weblogic-source/jms-sender/src/main/java/com/sample/jms/toolkit/JMSSender.java
+++ b/connect/connect-jms-weblogic-source/jms-sender/src/main/java/com/sample/jms/toolkit/JMSSender.java
@@ -1,5 +1,6 @@
 package com.sample.jms.toolkit;
 
+import java.util.Enumeration;
 import java.util.Hashtable;
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
@@ -7,6 +8,9 @@ import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageProducer;
 import javax.jms.Queue;
+import javax.jms.QueueBrowser;
+import javax.jms.QueueConnection;
+import javax.jms.QueueConnectionFactory;
 import javax.jms.QueueSession;
 import javax.jms.Session;
 import javax.jms.Topic;
@@ -24,7 +28,11 @@ public class JMSSender {
 	public final static String URL = "t3://weblogic-jms:7001";
 
 	public static void main(String[] args) throws NamingException, JMSException {
-
+		// If "check" argument is provided, check queue status instead of sending messages
+		if (args.length > 0 && "check".equals(args[0])) {
+			checkQueueStatus();
+			return;
+		}
 
 		System.out.println("Sending message to queue");
 		Connection connection = null;
@@ -87,5 +95,47 @@ public class JMSSender {
 		env.put(Context.INITIAL_CONTEXT_FACTORY, JNDI_FACTORY);
 		env.put(Context.PROVIDER_URL, URL);
 		return new InitialContext(env);
+	}
+
+	private static void checkQueueStatus() throws NamingException, JMSException {
+		QueueConnection connection = null;
+		try {
+			// Create initial context with credentials for queue checking
+			Hashtable env = new Hashtable();
+			env.put(Context.INITIAL_CONTEXT_FACTORY, JNDI_FACTORY);
+			env.put(Context.PROVIDER_URL, URL);
+			env.put(Context.SECURITY_PRINCIPAL, "weblogic");
+			env.put(Context.SECURITY_CREDENTIALS, "welcome1");
+			Context context = new InitialContext(env);
+			ConnectionFactory connectionFactory = (ConnectionFactory) context.lookup("myFactory");
+			QueueConnectionFactory qcf = (QueueConnectionFactory) connectionFactory;
+			connection = qcf.createQueueConnection();
+			QueueSession session = connection.createQueueSession(false, Session.AUTO_ACKNOWLEDGE);
+			Queue queue = (Queue) context.lookup("myQueue");
+			connection.start();
+
+			// Use QueueBrowser to peek at messages without consuming them
+			QueueBrowser browser = session.createBrowser(queue);
+			Enumeration messages = browser.getEnumeration();
+
+			int messageCount = 0;
+			while (messages.hasMoreElements()) {
+				messages.nextElement();
+				messageCount++;
+			}
+			browser.close();
+
+			if (messageCount == 0) {
+				System.out.println("Queue is empty - messages were successfully consumed and deleted");
+				System.exit(0);
+			} else {
+				System.out.println("Queue still contains " + messageCount + " message(s) - messages were not deleted");
+				System.exit(1);
+			}
+		} finally {
+			if (connection != null) {
+				connection.close();
+			}
+		}
 	}
 }

--- a/connect/connect-jms-weblogic-source/jms-weblogic-source.sh
+++ b/connect/connect-jms-weblogic-source/jms-weblogic-source.sh
@@ -94,4 +94,12 @@ sleep 5
 log "Verify we have received the data in from-weblogic-messages topic"
 playground topic consume --topic from-weblogic-messages --min-expected-messages 1 --timeout 60
 
+sleep 5
 
+log "Asserting that WebLogic JMS queue is empty after connector processing"
+if docker exec jms-sender bash -c 'java -cp "/tmp/weblogic.jar:/tmp/wlthint3client.jar:/jms-sender-1.0.0.jar" com.sample.jms.toolkit.JMSSender check'; then
+    log "✅ SUCCESS: WebLogic JMS queue is empty - message was successfully consumed and deleted"
+else
+    log "❌ FAILURE: Messages still remain in WebLogic JMS queue - message was not deleted"
+    exit 1
+fi


### PR DESCRIPTION
- Add assertion to verify Weblogic queue is empty after connector processing
- Tests that commitRecord API properly deletes messages from external system


```
12:45:13 ℹ️ Asserting that WebLogic JMS queue is empty after connector processing
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by weblogic.rjvm.MsgAbbrevInputStream (file:/tmp/wlthint3client.jar) to method java.io.ObjectInputStream.clear()
WARNING: Please consider reporting this to the maintainers of weblogic.rjvm.MsgAbbrevInputStream
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Queue is empty - messages were successfully consumed and deleted
12:45:14 ℹ️ ✅ SUCCESS: WebLogic JMS queue is empty - message was successfully consumed and deleted
12:45:14 ℹ️ ####################################################
12:45:14 ℹ️ ✅ RESULT: SUCCESS for jms-weblogic-source.sh (took: 1min 43sec - )
12:45:14 ℹ️ ####################################################
```
