### PR TITLE
Add commit api assertion to active mq source 

### DIFF
--- a/connect/connect-active-mq-source/active-mq-source.sh
+++ b/connect/connect-active-mq-source/active-mq-source.sh
@@ -38,3 +38,25 @@ sleep 5
 
 log "Verify we have received the data in MyKafkaTopicName topic"
 playground topic consume --topic MyKafkaTopicName --min-expected-messages 1 --timeout 60
+
+sleep 5
+
+log "Asserting that ActiveMQ queue DEV.QUEUE.1 is empty after connector processing"
+log "This tests that commitRecord API properly deletes messages from external system"
+QUEUE_SIZE=$(curl -s -u admin:admin "http://localhost:8161/admin/xml/queues.jsp" | grep -A 5 "DEV.QUEUE.1" | grep "size" | sed 's/.*size=\"\([0-9]*\)\".*/\1/')
+
+if [ -z "$QUEUE_SIZE" ]; then
+    logerror "❌ Failed to retrieve queue size from ActiveMQ"
+    exit 1
+fi
+
+log "Current queue size for DEV.QUEUE.1: $QUEUE_SIZE"
+
+if [ "$QUEUE_SIZE" -eq 0 ]; then
+    log "✅ SUCCESS: ActiveMQ queue DEV.QUEUE.1 is empty - message was successfully consumed and deleted"
+else
+    logerror "❌ FAILURE: Messages still remain in ActiveMQ queue DEV.QUEUE.1 (size: $QUEUE_SIZE) - message was not deleted"
+    log "Displaying queue statistics:"
+    curl -s -u admin:admin "http://localhost:8161/admin/xml/queues.jsp" | grep -A 10 "DEV.QUEUE.1"
+    exit 1
+fi


### PR DESCRIPTION
- Add assertion to verify ActiveMQ queue is empty after connector processing
- Tests that commitRecord API properly deletes messages from external system

```
19:19:29 ℹ️ Sending messages to DEV.QUEUE.1 JMS queue:
Message sent19:19:34 ℹ️ Verify we have received the data in MyKafkaTopicName topic
OpenJDK 64-Bit Server VM warning: Unable to get SVE vector length on this system. Disabling SVE. Specify -XX:UseSVE=0 to shun this warning.
RID:activemq-36409-1763646538755-4:1:1:1:text��f
queueDEV.QUEUE.1
message
Processed a total of 1 messages
19:19:44 ℹ️ Asserting that ActiveMQ queue DEV.QUEUE.1 is empty after connector processing
19:19:44 ℹ️ This tests that commitRecord API properly deletes messages from external system
19:19:44 ℹ️ Current queue size for DEV.QUEUE.1: 0
19:19:44 ℹ️ ✅ SUCCESS: ActiveMQ queue DEV.QUEUE.1 is empty - message was successfully consumed and deleted
19:19:44 ℹ️ ####################################################
19:19:44 ℹ️ ✅ RESULT: SUCCESS for active-mq-source.sh (took: 1min 1sec - )
19:19:44 ℹ️ ####################################################

```