### PR TITLE
CC-37840 Add streaming suffix for snowflake snowpipe streaming test

### DIFF
--- a/connect/connect-snowflake-sink/snowflake-sink-snowpipe-streaming.sh
+++ b/connect/connect-snowflake-sink/snowflake-sink-snowpipe-streaming.sh
@@ -9,16 +9,16 @@ source ${DIR}/../../scripts/utils.sh
 username=$(whoami)
 uppercase_username=$(echo $username | tr '[:lower:]' '[:upper:]')
 
-PLAYGROUND_DB=PG_DB_${uppercase_username}${TAG}
+PLAYGROUND_DB=PG_DB_${uppercase_username}${TAG}_streaming
 PLAYGROUND_DB=${PLAYGROUND_DB//[-._]/}
 
-PLAYGROUND_WAREHOUSE=PG_WH_${uppercase_username}${TAG}
+PLAYGROUND_WAREHOUSE=PG_WH_${uppercase_username}${TAG}_streaming
 PLAYGROUND_WAREHOUSE=${PLAYGROUND_WAREHOUSE//[-._]/}
 
-PLAYGROUND_CONNECTOR_ROLE=PG_ROLE_${uppercase_username}${TAG}
+PLAYGROUND_CONNECTOR_ROLE=PG_ROLE_${uppercase_username}${TAG}_streaming
 PLAYGROUND_CONNECTOR_ROLE=${PLAYGROUND_CONNECTOR_ROLE//[-._]/}
 
-PLAYGROUND_USER=PG_USER_${uppercase_username}${TAG}
+PLAYGROUND_USER=PG_USER_${uppercase_username}${TAG}_streaming
 PLAYGROUND_USER=${PLAYGROUND_USER//[-._]/}
 
 SNOWFLAKE_ACCOUNT_NAME=${SNOWFLAKE_ACCOUNT_NAME:-$1}


### PR DESCRIPTION
While running tests in parallel, both snowflake-sink.sh and snowflake-sink-snowpipe-streaming.sh use the same database, warehouse, and username, which can lead to conflicts.
This PR resolves the issue by adding a unique suffix to the streaming test resources.

Test - https://semaphore.ci.confluent.io/workflows/54d60b58-553d-480f-8744-dcc6d566e27e?pipeline_id=4681a658-c243-42a3-bb48-0cab1a4eb1b3