### PR TITLE
Ensure jcl-over-slf4j JAR is present

### DIFF
--- a/connect/connect-http-source/http-source-oauth2.sh
+++ b/connect/connect-http-source/http-source-oauth2.sh
@@ -11,7 +11,12 @@ then
 fi
 
 source ${DIR}/../../scripts/utils.sh
-
+cd ../../connect/connect-http-source
+if [ ! -f jcl-over-slf4j-2.0.7.jar ]
+then
+     wget -q https://repo1.maven.org/maven2/org/slf4j/jcl-over-slf4j/2.0.7/jcl-over-slf4j-2.0.7.jar
+fi
+cd -
 
 cd ../../connect/connect-http-source
 


### PR DESCRIPTION
Add check and download for jcl-over-slf4j JAR file


### Testing

```
playground run -f http-source-oauth2.sh --enable-control-center
12:19:16 ℹ️ 🛑 Stopping example http-source-oauth2.sh in dir /Users/sparshgupta/confluentinc/kafka-docker-playground/connect/connect-http-source
12:19:18 ℹ️ 🚀 Running example with flags
12:19:18 ℹ️ ⛳ Flags used are --enable-control-center
12:19:19 ℹ️ 📋 command to run again example has been copied to the clipboard (disable with 'playground config clipboard false')
12:19:19 ℹ️ 🚀 Number of examples ran so far: 2
12:19:20 ℹ️ ####################################################
12:19:20 ℹ️ 🚀 Executing http-source-oauth2.sh in dir /Users/sparshgupta/confluentinc/kafka-docker-playground/connect/connect-http-source
12:19:20 ℹ️ ####################################################
http-source-oauth2.sh: line 6: connect_cp_version_greater_than_8: command not found
12:19:23 ℹ️ 💫 Using default CP version 8.1.0
12:19:23 ℹ️ 🎓 Use --tag option to specify different version, see https://kafka-docker-playground.io/#/how-to-use?id=🎯-for-confluent-platform-cp
12:19:23 ℹ️ 💠⭐ Using CP Control Center Next Gen
12:19:23 ℹ️ 🧰 Checking if Docker image confluentinc/cp-server-connect-base:8.1.0 contains additional tools
12:19:23 ℹ️ ⏳ it can take a while if image is downloaded for the first time
12:19:24 ℹ️ 🎱 Installing connector confluentinc/kafka-connect-http-source:latest
Downloading component Kafka Connect HTTP Source Connector 1.0.1, provided by Confluent, Inc. from Confluent Hub and installing into /usr/share/confluent-hub-components
12:19:48 ℹ️ 💫 Using connector:
12:19:48 ℹ️     🔗 Plugin: confluentinc/kafka-connect-http-source:1.0.1
12:19:48 ℹ️     📅 Release date: 2025-06-28
12:19:48 ℹ️     🌐 Documentation: https://docs.confluent.io/kafka-connectors/http-source/current/overview.html
12:19:48 ℹ️ 🎓 To specify different version, check the documentation https://kafka-docker-playground.io/#/how-to-use?id=🔗-for-connectors
12:19:48 ℹ️ 🛰️ Starting up Confluent Platform in Kraft mode as CP version is > 8
cp: ../../connect/connect-http-source/jcl-over-slf4j-2.0.7.jar: No such file or directory
12:19:49 🔥 ####################################################
12:19:49 🔥 🔥 RESULT: FAILURE for http-source-oauth2.sh (took: 0min 29sec - )
12:19:49 🔥 ####################################################
12:19:49 ℹ️ 🧑‍🚒 you can troubleshoot the issue by running:
playground container display-error-all-containers
12:19:49 ℹ️ 🧑‍🚒 open full logs with '<playground container logs --open --container <container>', example:
playground container logs --open --container connect

➜  connect-http-source git:(patch-1) ✗ playground run -f http-source-oauth2.sh --enable-control-center
12:20:39 ℹ️ 🛑 Stopping example http-source-oauth2.sh in dir /Users/sparshgupta/confluentinc/kafka-docker-playground/connect/connect-http-source
12:20:40 ℹ️ 🚀 Running example with flags
12:20:40 ℹ️ ⛳ Flags used are --enable-control-center
12:20:41 ℹ️ 📋 command to run again example has been copied to the clipboard (disable with 'playground config clipboard false')
12:20:42 ℹ️ 🚀 Number of examples ran so far: 3
12:20:43 ℹ️ ####################################################
12:20:43 ℹ️ 🚀 Executing http-source-oauth2.sh in dir /Users/sparshgupta/confluentinc/kafka-docker-playground/connect/connect-http-source
12:20:43 ℹ️ ####################################################
http-source-oauth2.sh: line 6: connect_cp_version_greater_than_8: command not found
12:20:46 ℹ️ 💫 Using default CP version 8.1.0
12:20:46 ℹ️ 🎓 Use --tag option to specify different version, see https://kafka-docker-playground.io/#/how-to-use?id=🎯-for-confluent-platform-cp
12:20:46 ℹ️ 💠⭐ Using CP Control Center Next Gen
12:20:46 ℹ️ 🧰 Checking if Docker image confluentinc/cp-server-connect-base:8.1.0 contains additional tools
12:20:46 ℹ️ ⏳ it can take a while if image is downloaded for the first time
12:20:47 ℹ️ 🎱 Installing connector confluentinc/kafka-connect-http-source:latest
Downloading component Kafka Connect HTTP Source Connector 1.0.1, provided by Confluent, Inc. from Confluent Hub and installing into /usr/share/confluent-hub-components
12:21:05 ℹ️ 💫 Using connector:
12:21:05 ℹ️     🔗 Plugin: confluentinc/kafka-connect-http-source:1.0.1
12:21:05 ℹ️     📅 Release date: 2025-06-28
12:21:05 ℹ️     🌐 Documentation: https://docs.confluent.io/kafka-connectors/http-source/current/overview.html
12:21:05 ℹ️ 🎓 To specify different version, check the documentation https://kafka-docker-playground.io/#/how-to-use?id=🔗-for-connectors
12:21:05 ℹ️ 🛰️ Starting up Confluent Platform in Kraft mode as CP version is > 8
/Users/sparshgupta/confluentinc/kafka-docker-playground/connect/connect-http-source
/Users/sparshgupta/confluentinc/kafka-docker-playground/connect/connect-http-source
12:21:08 ℹ️ 🛑 Stopping example http-source-oauth2.sh in dir /Users/sparshgupta/confluentinc/kafka-docker-playground/connect/connect-http-source
12:21:09 ℹ️ 🧰 Checking if Docker image confluentinc/cp-server-connect-base:8.1.0 contains additional tools
12:21:09 ℹ️ ⏳ it can take a while if image is downloaded for the first time
12:21:09 ℹ️ 🛰️ Starting up Confluent Platform in Kraft mode as ENABLE_KRAFT environment variable is set
From github.com:sp-gupta/kafka-docker-playground
 * [new branch]          ccloud-demo                             -> origin-1/ccloud-demo
 * [new branch]          copilot/connect-salesforce-bulkapi-sink -> origin-1/copilot/connect-salesforce-bulkapi-sink
 * [new branch]          imgbot                                  -> origin-1/imgbot
 * [new branch]          master                                  -> origin-1/master
 * [new branch]          pulkit-mariadb-source-sink              -> origin-1/pulkit-mariadb-source-sink
12:21:13 ℹ️ 🖥️ This example should work natively with ARM64
12:21:13 ℹ️ 🛑 zookeeper is disabled
12:21:14 ℹ️ 💠 control-center is enabled
12:21:14 ℹ️ Use http://localhost:9021 to login
12:21:14 ℹ️ 🛑 Starting services without Flink
12:21:14 ℹ️ 🛑 ksqldb is disabled
12:21:14 ℹ️ 🛑 REST Proxy is disabled
12:21:15 ℹ️ 🛑 Grafana is disabled
12:21:15 ℹ️ 🛑 kcat is disabled
12:21:15 ℹ️ 🛑 conduktor is disabled
[+] Running 1/0
 ✔ Network plaintext_default  Removed                                                                                                                              0.0s
[+] Running 9/9
 ✔ Network plaintext_default     Created                                                                                                                           0.0s
 ✔ Container prometheus-c3-v2    Started                                                                                                                           0.1s
 ✔ Container controller          Started                                                                                                                           0.1s
 ✔ Container httpserver          Started                                                                                                                           0.1s
 ✔ Container broker              Started                                                                                                                           0.0s
 ✔ Container alertmanager-c3-v2  Started                                                                                                                           0.0s
 ✔ Container schema-registry     Started                                                                                                                           0.0s
 ✔ Container connect             Started                                                                                                                           0.0s
 ✔ Container control-center      Started                                                                                                                           0.0s
12:21:18 ℹ️ 📝 To see the actual properties file, use cli command 'playground container get-properties -c <container>'
12:21:19 ℹ️ ✨ If you modify a docker-compose file and want to re-create the container(s), run cli command 'playground container recreate'
12:21:19 ℹ️ ⌛ Waiting up to 300 seconds for connect to start
12:21:39 ℹ️ 🚦 containers have started!
12:21:39 ℹ️ 📊 JMX metrics are available locally on those ports:
12:21:39 ℹ️     - kraft-controller : 10005
12:21:39 ℹ️     - zookeeper       : 9999
12:21:39 ℹ️     - broker          : 10000
12:21:39 ℹ️     - schema-registry : 10001
12:21:39 ℹ️     - connect         : 10002
12:21:39 ℹ️ Creating http-source connector
12:21:41 ℹ️ 🛠️ Creating 🌎onprem connector http-source
12:21:43 ℹ️ 📋 🌎onprem connector config has been copied to the clipboard (disable with 'playground config clipboard false')
12:21:43 ℹ️ ✅ 🌎onprem connector http-source was successfully created
12:21:44 ℹ️ 🧰 Current config for 🌎onprem connector http-source
playground connector create-or-update --connector http-source --no-clipboard << EOF
{
  "auth.type": "oauth2",
  "confluent.topic.bootstrap.servers": "broker:9092",
  "confluent.topic.replication.factor": "1",
  "connector.class": "io.confluent.connect.http.HttpSourceConnector",
  "entity.names": "messages",
  "http.initial.offset": "1",
  "http.offset.mode": "SIMPLE_INCREMENTING",
  "key.converter": "org.apache.kafka.connect.storage.StringConverter",
  "oauth2.client.id": "kc-client",
  "oauth2.client.secret": "kc-secret",
  "oauth2.token.url": "http://httpserver:8080/oauth/token",
  "tasks.max": "1",
  "topic.name.pattern": "http-topic-\${entityName}",
  "url": "http://httpserver:8080/api/messages",
  "value.converter": "org.apache.kafka.connect.storage.StringConverter"
}
EOF
12:21:47 ℹ️ 🔩 list of all available parameters for 🌎onprem connector http-source (io.confluent.connect.http.HttpSourceConnector) and version unknown (with default value when applicable)
    "any": "STRING",
    "auth.type": "none",
    "bearer.token": "[hidden]",
    "confluent.license": "[hidden]",
    "confluent.topic.bootstrap.servers": "",
    "confluent.topic.replication.factor": "3",
    "confluent.topic": "_confluent-command",
    "connection.allow.cidr.ranges": "LIST",
    "connection.disallow.cidr.ranges": "LIST",
    "connection.disallow.class.e.ips": "false",
    "connection.disallow.local.ips": "false",
    "connection.disallow.private.ips": "false",
    "connection.password": "[hidden]",
    "connection.user": "STRING",
    "entity.names": "LIST",
    "http.initial.offset": "STRING",
    "http.next.page.json.pointer": "STRING",
    "http.offset.json.pointer": "STRING",
    "http.offset.mode": "simple_incrementing",
    "http.proxy.host": "STRING",
    "http.proxy.password": "[hidden]",
    "http.proxy.port": "0",
    "http.proxy.user": "STRING",
    "http.request.body": "STRING",
    "http.request.headers.separator": "|",
    "http.request.headers": "STRING",
    "http.request.method": "get",
    "http.request.parameters.separator": "&",
    "http.request.parameters": "STRING",
    "http.request.sensitive.headers": "[hidden]",
    "http.response.data.json.pointer": "STRING",
    "https.ssl.cipher.suites": "",
    "https.ssl.enabled.protocols": "TLSv1.2,TLSv1.3",
    "https.ssl.enabled": "false",
    "https.ssl.endpoint.identification.algorithm": "https",
    "https.ssl.engine.factory.class": "",
    "https.ssl.key.password": "",
    "https.ssl.keymanager.algorithm": "SunX509",
    "https.ssl.keystore.certificate.chain": "",
    "https.ssl.keystore.key": "",
    "https.ssl.keystore.location": "",
    "https.ssl.keystore.password": "",
    "https.ssl.keystore.type": "JKS",
    "https.ssl.protocol": "TLSv1.3",
    "https.ssl.provider": "",
    "https.ssl.secure.random.implementation": "",
    "https.ssl.trustmanager.algorithm": "PKIX",
    "https.ssl.truststore.certificates": "",
    "https.ssl.truststore.location": "",
    "https.ssl.truststore.password": "",
    "https.ssl.truststore.type": "JKS",
    "key.converter.converter.encoding": "UTF-8",
    "key.converter.converter.type": "",
    "max.in.flight.requests": "10",
    "max.retries": "10",
    "oauth2.client.id": "STRING",
    "oauth2.client.mode": "header",
    "oauth2.client.secret": "[hidden]",
    "oauth2.token.property": "access_token",
    "oauth2.token.url": "STRING",
    "request.interval.ms": "",
    "retry.backoff.ms": "3000",
    "retry.on.status.codes": "400-",
    "sensitive.headers.list": "authorization",
    "sensitive.headers.validation.enabled": "true",
    "topic.name.pattern": "",
    "url": "",
    "use.http.offset.json.pointer.as.string": "true",
    "value.converter.converter.encoding": "UTF-8",
    "value.converter.converter.type": "",
12:21:53 ℹ️ 🧩 Displaying status for 🌎onprem connector http-source
Name                           Status       Tasks                                                        Stack Trace
-------------------------------------------------------------------------------------------------------------
http-source                    ✅ RUNNING  0:🟢 RUNNING[connect]        -
-------------------------------------------------------------------------------------------------------------
12:21:54 ℹ️ 🌐 documentation for 🌎onprem connector kafka-connect-http-source is available at:
https://docs.confluent.io/kafka-connectors/http-source/current/overview.html
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   154    0   115  100    39   1430    484 --:--:-- --:--:-- --:--:--  1925
12:21:58 ℹ️ Send a message to HTTP server
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    57    0    41  100    16    360    140 --:--:-- --:--:-- --:--:--   504
{
  "id": 1,
  "message": "{\"test\":\"value\"}"
}
12:22:00 ℹ️ Verify we have received the data in http-topic-messages topic
12:22:04 ℹ️ ✨ Display content of topic http-topic-messages, it contains 58 messages
12:22:05 ℹ️ 🔮🙅 topic is not using any schema for key
12:22:05 ℹ️ 🔮🙅 topic is not using any schema for value
CreateTime:2025-12-08 12:21:58.656|Partition:0|Offset:0|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:21:58.758|Partition:0|Offset:1|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:21:58.860|Partition:0|Offset:2|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:21:58.962|Partition:0|Offset:3|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:21:59.64|Partition:0|Offset:4|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:21:59.167|Partition:0|Offset:5|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:21:59.272|Partition:0|Offset:6|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:21:59.372|Partition:0|Offset:7|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:21:59.478|Partition:0|Offset:8|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:21:59.580|Partition:0|Offset:9|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:21:59.681|Partition:0|Offset:10|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:21:59.783|Partition:0|Offset:11|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:21:59.885|Partition:0|Offset:12|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:21:59.991|Partition:0|Offset:13|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:00.92|Partition:0|Offset:14|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:00.196|Partition:0|Offset:15|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:00.298|Partition:0|Offset:16|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:00.399|Partition:0|Offset:17|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:00.501|Partition:0|Offset:18|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:00.612|Partition:0|Offset:19|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:00.723|Partition:0|Offset:20|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:00.825|Partition:0|Offset:21|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:00.925|Partition:0|Offset:22|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:01.26|Partition:0|Offset:23|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:01.127|Partition:0|Offset:24|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:01.228|Partition:0|Offset:25|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:01.330|Partition:0|Offset:26|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:01.432|Partition:0|Offset:27|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:01.534|Partition:0|Offset:28|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:01.636|Partition:0|Offset:29|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:01.738|Partition:0|Offset:30|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:01.839|Partition:0|Offset:31|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:01.941|Partition:0|Offset:32|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:02.43|Partition:0|Offset:33|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:02.145|Partition:0|Offset:34|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:02.247|Partition:0|Offset:35|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:02.349|Partition:0|Offset:36|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:02.453|Partition:0|Offset:37|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:02.556|Partition:0|Offset:38|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:02.658|Partition:0|Offset:39|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:02.761|Partition:0|Offset:40|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:02.863|Partition:0|Offset:41|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:02.963|Partition:0|Offset:42|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:03.66|Partition:0|Offset:43|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:03.168|Partition:0|Offset:44|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:03.269|Partition:0|Offset:45|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:03.370|Partition:0|Offset:46|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:03.471|Partition:0|Offset:47|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:03.572|Partition:0|Offset:48|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:03.673|Partition:0|Offset:49|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:03.774|Partition:0|Offset:50|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:03.876|Partition:0|Offset:51|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:03.977|Partition:0|Offset:52|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:04.78|Partition:0|Offset:53|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:04.180|Partition:0|Offset:54|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:04.282|Partition:0|Offset:55|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:04.382|Partition:0|Offset:56|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
CreateTime:2025-12-08 12:22:04.483|Partition:0|Offset:57|Headers:NO_HEADERS|Key:null|Value:Struct{id=1,message={"test":"value"}}|ValueSchemaId:
12:22:11 ℹ️ ####################################################
12:22:11 ℹ️ ✅ RESULT: SUCCESS for http-source-oauth2.sh (took: 1min 28sec - )
12:22:11 ℹ️ ####################################################

11:26:00 ℹ️ file /Users/sparshgupta/confluentinc/kafka-docker-playground/scripts/cli/confluent-hub-plugin-list.txt not found. Generating it now, it may take a while...
11:26:07 ℹ️ 🆕 Listing last updated connector plugins (within 3 days) for confluentinc vendor
🔌 confluentinc/kafka-connect-avro-converter - 🔢 v8.1.1 - 📅 release date: 2025-12-05 (2 days ago) - 🌐 documentation: https://docs.confluent.io/current/schema-registry/docs/connect.html
🔌 confluentinc/kafka-connect-hdfs3 - 🔢 v3.0.5 - 📅 release date: 2025-12-04 (3 days ago) - 🌐 documentation: https://docs.confluent.io/kafka-connect-hdfs3-sink/current/index.html
🔌 confluentinc/kafka-connect-json-schema-converter - 🔢 v8.1.1 - 📅 release date: 2025-12-05 (2 days ago) - 🌐 documentation: https://docs.confluent.io/current/schema-registry/docs/connect.html
🔌 confluentinc/kafka-connect-protobuf-converter - 🔢 v8.1.1 - 📅 release date: 2025-12-05 (2 days ago) - 🌐 documentation: https://docs.confluent.io/current/schema-registry/docs/connect.html
🔌 confluentinc/kafka-connect-replicator - 🔢 v8.1.1 - 📅 release date: 2025-12-05 (2 days ago) - 🌐 documentation: https://docs.confluent.io/kafka-connect-replicator/current/index.html
12:22:15 ℹ️ 🎯 Version currently used for confluent platform
8.1.0
12:22:16 ℹ️ 💯 Listing last 5 versions for connector plugin confluentinc/kafka-connect-http-source
🔢 v0.2.4 - 📅 release date: 2024-10-18 (415 days ago)
🔢 v0.2.5 - 📅 release date: 2024-11-04 (398 days ago)
🔢 v0.2.6 - 📅 release date: 2025-03-21 (261 days ago)
🔢 v1.0.0 - 📅 release date: 2025-06-04 (186 days ago)
🔢 v1.0.1 - 📅 release date: 2025-06-28 (162 days ago)
🌐 documentation: https://docs.confluent.io/kafka-connectors/http-source/current/overview.html
12:22:16 ℹ️ 👻 Version currently used for confluentinc/kafka-connect-http-source is latest
🔢 v1.0.1 - 📅 release date: 2025-06-28
12:22:17 ℹ️ 🧩 Displaying status for 🌎onprem connector http-source
Name                           Status       Tasks                                                        Stack Trace
-------------------------------------------------------------------------------------------------------------
http-source                    ✅ RUNNING  0:🟢 RUNNING[connect]        -
-------------------------------------------------------------------------------------------------------------
```