### PR TITLE
Disable ssl verification for mssql jdbc driver download

### DIFF
--- a/connect/connect-jdbc-azure-synapse-analytics-source/jdbc-azure-synapse-analytics-source.sh
+++ b/connect/connect-jdbc-azure-synapse-analytics-source/jdbc-azure-synapse-analytics-source.sh
@@ -15,7 +15,7 @@ cd ../../connect/connect-jdbc-azure-synapse-analytics-source
 if [ ! -f ${PWD}/sqljdbc_12.2/enu/mssql-jdbc-12.2.0.jre11.jar ]
 then
      log "Downloading Microsoft JDBC driver mssql-jdbc-12.2.0.jre11.jar"
-     curl -L https://go.microsoft.com/fwlink/?linkid=2222954 -o sqljdbc_12.2.0.0_enu.tar.gz
+     curl -k -L https://go.microsoft.com/fwlink/?linkid=2222954 -o sqljdbc_12.2.0.0_enu.tar.gz
      tar xvfz sqljdbc_12.2.0.0_enu.tar.gz
      rm -f sqljdbc_12.2.0.0_enu.tar.gz
 fi

--- a/connect/connect-jdbc-sqlserver-sink/sqlserver-microsoft-sink-ssl.sh
+++ b/connect/connect-jdbc-sqlserver-sink/sqlserver-microsoft-sink-ssl.sh
@@ -15,7 +15,7 @@ cd ../../connect/connect-jdbc-sqlserver-sink
 if [ ! -f ${PWD}/sqljdbc_12.2/enu/mssql-jdbc-12.2.0.jre11.jar ]
 then
      log "Downloading Microsoft JDBC driver mssql-jdbc-12.2.0.jre11.jar"
-     curl -L https://go.microsoft.com/fwlink/?linkid=2222954 -o sqljdbc_12.2.0.0_enu.tar.gz
+     curl -k -L https://go.microsoft.com/fwlink/?linkid=2222954 -o sqljdbc_12.2.0.0_enu.tar.gz
      tar xvfz sqljdbc_12.2.0.0_enu.tar.gz
      rm -f sqljdbc_12.2.0.0_enu.tar.gz
 fi

--- a/connect/connect-jdbc-sqlserver-sink/sqlserver-microsoft-sink.sh
+++ b/connect/connect-jdbc-sqlserver-sink/sqlserver-microsoft-sink.sh
@@ -15,7 +15,7 @@ cd ../../connect/connect-jdbc-sqlserver-sink
 if [ ! -f ${PWD}/sqljdbc_12.2/enu/mssql-jdbc-12.2.0.jre11.jar ]
 then
      log "Downloading Microsoft JDBC driver mssql-jdbc-12.2.0.jre11.jar"
-     curl -L https://go.microsoft.com/fwlink/?linkid=2222954 -o sqljdbc_12.2.0.0_enu.tar.gz
+     curl -k -L https://go.microsoft.com/fwlink/?linkid=2222954 -o sqljdbc_12.2.0.0_enu.tar.gz
      tar xvfz sqljdbc_12.2.0.0_enu.tar.gz
      rm -f sqljdbc_12.2.0.0_enu.tar.gz
 fi

--- a/connect/connect-jdbc-sqlserver-source/sqlserver-microsoft-ssl.sh
+++ b/connect/connect-jdbc-sqlserver-source/sqlserver-microsoft-ssl.sh
@@ -15,7 +15,7 @@ cd ../../connect/connect-jdbc-sqlserver-source
 if [ ! -f ${PWD}/sqljdbc_12.2/enu/mssql-jdbc-12.2.0.jre11.jar ]
 then
      log "Downloading Microsoft JDBC driver mssql-jdbc-12.2.0.jre11.jar"
-     curl -L https://go.microsoft.com/fwlink/?linkid=2222954 -o sqljdbc_12.2.0.0_enu.tar.gz
+     curl -k -L https://go.microsoft.com/fwlink/?linkid=2222954 -o sqljdbc_12.2.0.0_enu.tar.gz
      tar xvfz sqljdbc_12.2.0.0_enu.tar.gz
      rm -f sqljdbc_12.2.0.0_enu.tar.gz
 fi

--- a/connect/connect-jdbc-sqlserver-source/sqlserver-microsoft.sh
+++ b/connect/connect-jdbc-sqlserver-source/sqlserver-microsoft.sh
@@ -15,7 +15,7 @@ cd ../../connect/connect-jdbc-sqlserver-source
 if [ ! -f ${PWD}/sqljdbc_12.2/enu/mssql-jdbc-12.2.0.jre11.jar ]
 then
      log "Downloading Microsoft JDBC driver mssql-jdbc-12.2.0.jre11.jar"
-     curl -L https://go.microsoft.com/fwlink/?linkid=2222954 -o sqljdbc_12.2.0.0_enu.tar.gz
+     curl -k -L https://go.microsoft.com/fwlink/?linkid=2222954 -o sqljdbc_12.2.0.0_enu.tar.gz
      tar xvfz sqljdbc_12.2.0.0_enu.tar.gz
      rm -f sqljdbc_12.2.0.0_enu.tar.gz
 fi


### PR DESCRIPTION
On the EC2 instance type s1-prod-ubuntu24-04-amd64-2, SSL certificate verification fails while downloading the Microsoft SQL Server JDBC driver. This causes the MicrosoftSqlServer integration tests to fail.

The failure appears to be related to a certificate chain change behind the Microsoft redirect URL: https://go.microsoft.com/fwlink/?linkid=2222954.

When inspecting the endpoint using openssl, the TLS handshake fails with a certificate verification error:
```
---
Server certificate
subject=C = US, ST = WA, L = Redmond, O = Microsoft Corporation, CN = akamai.download.microsoft.com
issuer=C = US, O = Microsoft Corporation, CN = Microsoft TLS G2 ECC CA OCSP 02
---
No client certificate CA names sent
Peer signing digest: SHA256
Peer signature type: ECDSA
Server Temp Key: ECDH, prime256v1, 256 bits
---
SSL handshake has read 2298 bytes and written 450 bytes
Verification error: unable to verify the first certificate
Verify return code: 21 (unable to verify the first certificate)
```

As a temporary workaround, this change switches the JDBC driver download to insecure mode to unblock CI and restore test stability.
This should be reverted once the underlying certificate chain issue is resolved.