### PR TITLE
Fix and update docker playground test for Solace Specific Source Connector

### DIFF
--- a/connect/connect-solace-source/README.md
+++ b/connect/connect-solace-source/README.md
@@ -40,6 +40,13 @@ permission all consume
 no shutdown full
 ```
 
+Create topic with `LogAppendTime` to avoid `CreateTime:0` timestamps:
+
+```bash
+playground topic create --topic from-solace-messages --nb-partitions 1
+playground topic alter --topic from-solace-messages --add-config message.timestamp.type=LogAppendTime
+```
+
 Publish messages to the Solace queue using the REST endpoint
 
 ```bash
@@ -74,10 +81,17 @@ $ curl -X PUT \
 Verify topic
 
 ```
-playground topic consume --topic from-solace-messages --min-expected-messages 2 --timeout 60
+playground topic consume --topic from-solace-messages --min-expected-messages 3 --timeout 60
 Struct{messageID=1000,messageType=text,timestamp=0,deliveryMode=2,destination=Struct{destinationType=queue,name=connector-quickstart},redelivered=false,expiration=0,priority=0,properties={JMS_Solace_isXML=Struct{propertyType=boolean,boolean=false}, JMS_Solace_DeliverToOne=Struct{propertyType=boolean,boolean=false}, JMS_Solace_DeadMsgQueueEligible=Struct{propertyType=boolean,boolean=false}, JMS_Solace_ElidingEligible=Struct{propertyType=boolean,boolean=false}, Solace_JMS_Prop_IS_Reply_Message=Struct{propertyType=boolean,boolean=false}, JMS_Solace_HTTPContentType=Struct{propertyType=string,string=text/plain}, JMSXDeliveryCount=Struct{propertyType=integer,integer=1}},text=m1}
 Struct{messageID=1001,messageType=text,timestamp=0,deliveryMode=2,destination=Struct{destinationType=queue,name=connector-quickstart},redelivered=false,expiration=0,priority=0,properties={JMS_Solace_isXML=Struct{propertyType=boolean,boolean=false}, JMS_Solace_DeliverToOne=Struct{propertyType=boolean,boolean=false}, JMS_Solace_DeadMsgQueueEligible=Struct{propertyType=boolean,boolean=false}, JMS_Solace_ElidingEligible=Struct{propertyType=boolean,boolean=false}, Solace_JMS_Prop_IS_Reply_Message=Struct{propertyType=boolean,boolean=false}, JMS_Solace_HTTPContentType=Struct{propertyType=string,string=text/plain}, JMSXDeliveryCount=Struct{propertyType=integer,integer=1}},text=m1}
-Processed a total of 2 messages
+Struct{messageID=1002,messageType=text,timestamp=0,deliveryMode=2,destination=Struct{destinationType=queue,name=connector-quickstart},redelivered=false,expiration=0,priority=0,properties={JMS_Solace_isXML=Struct{propertyType=boolean,boolean=false}, JMS_Solace_DeliverToOne=Struct{propertyType=boolean,boolean=false}, JMS_Solace_DeadMsgQueueEligible=Struct{propertyType=boolean,boolean=false}, JMS_Solace_ElidingEligible=Struct{propertyType=boolean,boolean=false}, Solace_JMS_Prop_IS_Reply_Message=Struct{propertyType=boolean,boolean=false}, JMS_Solace_HTTPContentType=Struct{propertyType=string,string=text/plain}, JMSXDeliveryCount=Struct{propertyType=integer,integer=1}},text=m1}
+Processed a total of 3 messages
+```
+
+Assert that the Solace queue is empty after connector processing (tests `commitRecord` API):
+
+```text
+✅ SUCCESS: Solace queue connector-quickstart is empty - messages were successfully consumed and deleted
 ```
 
 N.B: Control Center is reachable at [http://127.0.0.1:9021](http://127.0.0.1:9021])

--- a/connect/connect-solace-source/solace-source.sh
+++ b/connect/connect-solace-source/solace-source.sh
@@ -54,6 +54,10 @@ log "Solace UI is accessible at http://127.0.0.1:8080 (admin/admin)"
 log "Create the queue connector-quickstart in the default Message VPN using CLI"
 docker exec solace bash -c "/usr/sw/loads/currentload/bin/cli -A -s cliscripts/create_queue_cmd"
 
+# Setting message.timestamp.type=LogAppendTime otherwise we have CreateTime:0
+playground topic create --topic from-solace-messages --nb-partitions 1
+playground topic alter --topic from-solace-messages --add-config message.timestamp.type=LogAppendTime
+
 log "Publish messages to the Solace queue using the REST endpoint"
 
 for i in 1000 1001 1002
@@ -79,8 +83,10 @@ playground connector create-or-update --connector solace-source  << EOF
 }
 EOF
 
+sleep 10
+
 log "Verifying topic from-solace-messages"
-playground topic consume --topic from-solace-messages --min-expected-messages 2 --timeout 60
+playground topic consume --topic from-solace-messages --min-expected-messages 3 --timeout 60
 
 
 sleep 5


### PR DESCRIPTION
- Add topic pre-creation with `message.timestamp.type=LogAppendTime` to avoid `CreateTime:0` timestamps
- Add `sleep 10` before topic consumption to allow connector processing time
- Fix `--min-expected-messages 2` → `3` to match the 3 messages published
- Update README to reflect changes and document commitRecord assertion

Ref: CC-37959

```
00:05:44 ℹ️ ✅ 🌎onprem connector solace-source was successfully created
00:05:59 ℹ️ Verifying topic from-solace-messages
00:06:02 ℹ️ ✨ Display content of topic from-solace-messages, it contains 3 messages
LogAppendTime:1774722947442|Partition:0|Offset:0|NO_HEADERS|Struct{messageID=1000}|Struct{messageID=1000,messageType=text,...,text=m1}
LogAppendTime:1774722947442|Partition:0|Offset:1|NO_HEADERS|Struct{messageID=1001}|Struct{messageID=1001,messageType=text,...,text=m1}
LogAppendTime:1774722947442|Partition:0|Offset:2|NO_HEADERS|Struct{messageID=1002}|Struct{messageID=1002,messageType=text,...,text=m1}
00:06:12 ℹ️ Asserting that Solace queue connector-quickstart is empty after connector processing
00:06:12 ℹ️ This tests that commitRecord API properly deletes messages from external system
00:06:12 ℹ️ Current message spool usage for connector-quickstart: 0 bytes
00:06:12 ℹ️ ✅ SUCCESS: Solace queue connector-quickstart is empty - messages were successfully consumed and deleted
00:06:12 ℹ️ ####################################################
00:06:12 ℹ️ ✅ RESULT: SUCCESS for solace-source.sh (took: 1min 26sec - )
00:06:12 ℹ️ ####################################################
```