### PR TITLE
Fix ksqldb udf examples missing Confluent Maven repository

### DIFF
--- a/ksqldb/udf-logging/udf-custom-logger/pom.xml
+++ b/ksqldb/udf-logging/udf-custom-logger/pom.xml
@@ -17,6 +17,14 @@
         <logback.version>1.2.13</logback.version>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>confluent</id>
+            <name>Confluent</name>
+            <url>https://packages.confluent.io/maven/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>io.confluent.ksql</groupId>

--- a/ksqldb/udf-logging/udf-simple-logging/pom.xml
+++ b/ksqldb/udf-logging/udf-simple-logging/pom.xml
@@ -14,6 +14,14 @@
         <confluent.ksql-udf.version>5.4.4</confluent.ksql-udf.version>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>confluent</id>
+            <name>Confluent</name>
+            <url>https://packages.confluent.io/maven/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>io.confluent.ksql</groupId>


### PR DESCRIPTION
Add the Confluent Maven repository in the ksqldb UDF examples