### PR TITLE
Stop ActiveMQ connector before asserting queue emptiness

### DIFF
--- a/connect/connect-active-mq-source/active-mq-source.sh
+++ b/connect/connect-active-mq-source/active-mq-source.sh
@@ -41,6 +41,11 @@ playground topic consume --topic MyKafkaTopicName --min-expected-messages 1 --ti
 
 sleep 5
 
+log "Stopping the connector to force unacknowledged messages to be redelivered"
+playground connector stop --connector active-mq-source
+
+sleep 5
+
 log "Asserting that ActiveMQ queue DEV.QUEUE.1 is empty after connector processing"
 log "This tests that commitRecord API properly deletes messages from external system"
 QUEUE_SIZE=$(curl -s -u admin:admin "http://localhost:8161/admin/xml/queues.jsp" | grep -A 5 "DEV.QUEUE.1" | grep "size" | sed 's/.*size=\"\([0-9]*\)\".*/\1/')


### PR DESCRIPTION
## Summary
- Stop the ActiveMQ source connector before checking if the queue is empty, forcing unacknowledged messages to be redelivered and become visible
- This ensures the `commitRecord` API assertion is accurate — previously, JMS `CLIENT_ACKNOWLEDGE` mode kept consumed messages "in-flight" (invisible) while the connector was running, causing false passes
- Fixes CC-39834

## Test plan
- [x] Run `active-mq-source.sh` end-to-end with a working connector version — queue should be empty (size=0)

Test results:

```
`12:24:12 ℹ️ 📝 To see the actual properties file, use cli command 'playground container get-properties -c <container>
12:24:13 ℹ️ ✨ If you modify a docker-compose file and want to re-create the container(s), run cli command 'playground container recreate'
12:24:13 ℹ️ ⌛ Waiting up to 300 seconds for connect to start
12:24:25 ℹ️ 🚦 containers have started! (took 12 seconds)
12:24:25 ℹ️ 📊 JMX metrics are available locally on those ports:
12:24:25 ℹ️     - kraft-controller : 10005
12:24:25 ℹ️     - zookeeper       : 9999
12:24:25 ℹ️     - broker          : 10000
12:24:25 ℹ️     - schema-registry : 10001
12:24:25 ℹ️     - connect         : 10002
12:24:25 ℹ️ Creating ActiveMQ source connector
12:24:28 ℹ️ 🛠️ Creating 🌎onprem connector active-mq-source
12:24:29 ℹ️ 📋 🌎onprem connector config has been copied to the clipboard (disable with 'playground config clipboard false')
12:24:29 ℹ️ ✅ 🌎onprem connector active-mq-source was successfully created
12:24:31 ℹ️ 🧰 Current config for 🌎onprem connector active-mq-source
playground connector create-or-update --connector active-mq-source --no-clipboard << EOF
{
  "activemq.url": "tcp://activemq:61616",
  "confluent.license": "",
  "confluent.topic.bootstrap.servers": "broker:9092",
  "confluent.topic.replication.factor": "1",
  "connector.class": "io.confluent.connect.activemq.ActiveMQSourceConnector",
  "jms.destination.name": "DEV.QUEUE.1",
  "jms.destination.type": "queue",
  "kafka.topic": "MyKafkaTopicName"
}
EOF
12:24:34 ℹ️ 🔩 list of all available parameters for 🌎onprem connector active-mq-source (io.confluent.connect.activemq.ActiveMQSourceConnector) and version 13.0.8 (with default value when applicable)
    "activemq.password": "[hidden]",
    "activemq.url": "",
    "activemq.username": "STRING",
    "batch.size": "1024",
    "behavior.on.error": "FAIL",
    "character.encoding": "UTF-8",
    "confluent.license": "[hidden]",
    "confluent.topic.bootstrap.servers": "",
    "confluent.topic.replication.factor": "3",
    "confluent.topic": "_confluent-command",
    "exactly.once.support": "requested",
    "initial.poll.wait.time.ms": "5000",
    "jms.destination.name": "",
    "jms.destination.type": "QUEUE",
    "jms.message.selector": "STRING",
    "jms.receive.block.duration": "5000",
    "jms.subscription.durable": "false",
    "jms.subscription.name": "STRING",
    "kafka.topic": "",
    "max.pending.messages": "4096",
    "max.poll.duration": "60000",
    "max.record.commit.timeout": "10",
    "max.retry.time": "3600000",
    "transaction.boundary.interval.ms": "",
    "transaction.boundary": "poll",
    "use.permissive.schema": "false",
12:24:36 ℹ️ 🧩 Displaying status for 🌎onprem connector active-mq-source
Name                           Status       Tasks                                                        Stack Trace                                       
-------------------------------------------------------------------------------------------------------------
active-mq-source               ✅ RUNNING  0:🟢 RUNNING                 -                                                 
-------------------------------------------------------------------------------------------------------------
12:24:39 ℹ️ 🌐 documentation for 🌎onprem connector kafka-connect-activemq is available at:
https://docs.confluent.io/kafka-connect-activemq-source/current/index.html
12:24:44 ℹ️ Sending messages to DEV.QUEUE.1 JMS queue:
Message sent12:24:49 ℹ️ Verify we have received the data in MyKafkaTopicName topic
OpenJDK 64-Bit Server VM warning: Unable to get SVE vector length on this system. Disabling SVE. Specify -XX:UseSVE=0 to shun this warning.
RID:activemq-34283-1776668053784-4:1:1:1:textԦܚ�g
queueDEV.QUEUE.1
message
Processed a total of 1 messages
12:24:59 ℹ️ Stopping the connector to force unacknowledged messages to be redelivered
12:25:00 ℹ️ 🛑 Stopping 🌎onprem connector active-mq-source
12:25:01 ℹ️ 🛑 🌎onprem connector active-mq-source has been stopped successfully
12:25:03 ℹ️ 🧩 Displaying status for 🌎onprem connector active-mq-source
Name                           Status       Tasks                                                        Stack Trace                                       
-------------------------------------------------------------------------------------------------------------
active-mq-source               🛑 STOPPED 0:🟢 RUNNING                 -                                                 
-------------------------------------------------------------------------------------------------------------
12:25:09 ℹ️ Asserting that ActiveMQ queue DEV.QUEUE.1 is empty after connector processing
12:25:09 ℹ️ This tests that commitRecord API properly deletes messages from external system
12:25:09 ℹ️ Current queue size for DEV.QUEUE.1: 0
12:25:09 ℹ️ ✅ SUCCESS: ActiveMQ queue DEV.QUEUE.1 is empty - message was successfully consumed and deleted
12:25:09 ℹ️ ####################################################
12:25:09 ℹ️ ✅ RESULT: SUCCESS for active-mq-source.sh (took: 1min 16sec - )
12:25:09 ℹ️ ####################################################

12:15:26 ℹ️ 🆕 Listing last updated connector plugins (within 3 days) for confluentinc vendor
12:25:15 ℹ️ 🎯 Version currently used for confluent platform
8.2.0
12:25:15 ℹ️ 💯 Listing last 5 versions for connector plugin confluentinc/kafka-connect-activemq
date: invalid option -- 'j'
Try 'date --help' for more information.
12:25:19 ℹ️ 🧩 Displaying status for 🌎onprem connector active-mq-source
Name                           Status       Tasks                                                        Stack Trace                                       
-------------------------------------------------------------------------------------------------------------
active-mq-source               🛑 STOPPED 🤔 N/A                       -                                                 
------------------------------------------------------------------------------------------------------------- 
```