### PR TITLE
Skip top-of-script version guards when CONNECTOR_TAG is empty

### DIFF
--- a/connect/connect-aws-s3-source/s3-source-backup-and-restore-with-assuming-iam-role-config.sh
+++ b/connect/connect-aws-s3-source/s3-source-backup-and-restore-with-assuming-iam-role-config.sh
@@ -4,7 +4,7 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/../../scripts/utils.sh
 
-if ! version_gt $CONNECTOR_TAG "2.5.0"; then
+if [ ! -z "$CONNECTOR_TAG" ] && ! version_gt $CONNECTOR_TAG "2.5.0"; then
     logwarn "this is available since version 2.5.1 only"
     exit 1
 fi

--- a/connect/connect-aws-s3-source/s3-source-generalized.sh
+++ b/connect/connect-aws-s3-source/s3-source-generalized.sh
@@ -4,7 +4,7 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/../../scripts/utils.sh
 
-if ! version_gt $CONNECTOR_TAG "1.9.9"; then
+if [ ! -z "$CONNECTOR_TAG" ] && ! version_gt $CONNECTOR_TAG "1.9.9"; then
     # skipped
     logwarn "skipped as it requires connector version 2.0.0"
     exit 111

--- a/connect/connect-azure-blob-storage-source/azure-blob-storage-source-generalized.sh
+++ b/connect/connect-azure-blob-storage-source/azure-blob-storage-source-generalized.sh
@@ -4,7 +4,7 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/../../scripts/utils.sh
 
-if ! version_gt $CONNECTOR_TAG "2.1.99"; then
+if [ ! -z "$CONNECTOR_TAG" ] && ! version_gt $CONNECTOR_TAG "2.1.99"; then
     # skipped
     logwarn "skipped as it requires connector version 2.2.0"
     exit 111

--- a/connect/connect-gcp-gcs-source/gcs-source-generalized.sh
+++ b/connect/connect-gcp-gcs-source/gcs-source-generalized.sh
@@ -4,7 +4,7 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/../../scripts/utils.sh
 
-if ! version_gt $CONNECTOR_TAG "2.0.99"; then
+if [ ! -z "$CONNECTOR_TAG" ] && ! version_gt $CONNECTOR_TAG "2.0.99"; then
     # skipped
     logwarn "skipped as it requires connector version 2.1.0"
     exit 111


### PR DESCRIPTION
Several connector test scripts have a top-of-script guard of the form

    if ! version_gt $CONNECTOR_TAG "X.Y.Z"; then
        logwarn "skipped as it requires connector version A.B.C"
        exit 111
    fi

When the test is run with --connector-zip (instead of --connector-tag), CONNECTOR_TAG is unset. version_gt is implemented with `printf %s\n | sort -V | head -n 1`, which puts the empty string first, so the test "first arg is not the smallest" returns false and the guard trips even though the local zip is presumably the version under test and should be allowed through.

Other guards in the same scripts (the CP-version Block 3 guards) already use `[ ! -z "$CONNECTOR_TAG" ] && version_gt ...`, treating an unknown tag as "no constraint." This change applies the same pattern to the top-of-script guards in:

  - connect-aws-s3-source/s3-source-generalized.sh
  - connect-aws-s3-source/s3-source-backup-and-restore-with-assuming-iam-role-config.sh
  - connect-azure-blob-storage-source/azure-blob-storage-source-generalized.sh
  - connect-gcp-gcs-source/gcs-source-generalized.sh