### PR TITLE
Fix Oracle XStream tests for releases where microdnf (or any other package manager) not present in docker images

### DIFF
--- a/connect/connect-cdc-xstream-oracle19-source/cdc-xstream-oracle19-blocking-snapshot-kafka-signal.sh
+++ b/connect/connect-cdc-xstream-oracle19-source/cdc-xstream-oracle19-blocking-snapshot-kafka-signal.sh
@@ -74,23 +74,17 @@ then
 fi
 
 # https://github.com/confluentinc/common-docker/pull/743 and https://github.com/adoptium/adoptium-support/issues/1285
-set +e
-playground container exec --root --command "sed -i "s/packages\.adoptium\.net/adoptium\.jfrog\.io/g" /etc/yum.repos.d/adoptium.repo"
-set -e
-playground container exec --root --command "microdnf -y install libaio"
-
-if [ "$(uname -m)" = "arm64" ]
-then
-     :
-else
-     if version_gt $TAG_BASE "7.9.9"
-     then
-          playground container exec --root --command "microdnf -y install libnsl2"
-          playground container exec --root --command "ln -s /usr/lib64/libnsl.so.3 /usr/lib64/libnsl.so.1"
-     else
-          playground container exec --root --command "ln -s /usr/lib64/libnsl.so.2 /usr/lib64/libnsl.so.1"
-     fi
-fi
+mkdir -p /tmp/xstream-libs
+docker run --rm -v /tmp/xstream-libs:/out --entrypoint sh redhat/ubi9-minimal:latest -c '
+  microdnf -y install libaio libnsl2 && \
+  cp -P /usr/lib64/libaio.so.* /usr/lib64/libnsl.so.* /usr/lib64/libtirpc.so.* \
+        /usr/lib64/libgssapi_krb5.so.* /usr/lib64/libkrb5.so.* /usr/lib64/libk5crypto.so.* \
+        /usr/lib64/libkrb5support.so.* /usr/lib64/libcom_err.so.* \
+        /usr/lib64/libkeyutils.so.* /out/
+'
+docker cp /tmp/xstream-libs/. connect:/usr/lib64/
+rm -rf /tmp/xstream-libs
+playground container exec --root --command "ldconfig && ln -sf /usr/lib64/libnsl.so.3 /usr/lib64/libnsl.so.1"
 
 playground container logs --container oracle --wait-for-log "DATABASE IS READY TO USE" --max-wait 600
 log "Oracle DB has started!"

--- a/connect/connect-cdc-xstream-oracle19-source/cdc-xstream-oracle19-blocking-snapshot.sh
+++ b/connect/connect-cdc-xstream-oracle19-source/cdc-xstream-oracle19-blocking-snapshot.sh
@@ -74,23 +74,17 @@ then
 fi
 
 # https://github.com/confluentinc/common-docker/pull/743 and https://github.com/adoptium/adoptium-support/issues/1285
-set +e
-playground container exec --root --command "sed -i "s/packages\.adoptium\.net/adoptium\.jfrog\.io/g" /etc/yum.repos.d/adoptium.repo"
-set -e
-playground container exec --root --command "microdnf -y install libaio"
-
-if [ "$(uname -m)" = "arm64" ]
-then
-     :
-else
-     if version_gt $TAG_BASE "7.9.9"
-     then
-          playground container exec --root --command "microdnf -y install libnsl2"
-          playground container exec --root --command "ln -s /usr/lib64/libnsl.so.3 /usr/lib64/libnsl.so.1"
-     else
-          playground container exec --root --command "ln -s /usr/lib64/libnsl.so.2 /usr/lib64/libnsl.so.1"
-     fi
-fi
+mkdir -p /tmp/xstream-libs
+docker run --rm -v /tmp/xstream-libs:/out --entrypoint sh redhat/ubi9-minimal:latest -c '
+  microdnf -y install libaio libnsl2 && \
+  cp -P /usr/lib64/libaio.so.* /usr/lib64/libnsl.so.* /usr/lib64/libtirpc.so.* \
+        /usr/lib64/libgssapi_krb5.so.* /usr/lib64/libkrb5.so.* /usr/lib64/libk5crypto.so.* \
+        /usr/lib64/libkrb5support.so.* /usr/lib64/libcom_err.so.* \
+        /usr/lib64/libkeyutils.so.* /out/
+'
+docker cp /tmp/xstream-libs/. connect:/usr/lib64/
+rm -rf /tmp/xstream-libs
+playground container exec --root --command "ldconfig && ln -sf /usr/lib64/libnsl.so.3 /usr/lib64/libnsl.so.1"
 
 playground container logs --container oracle --wait-for-log "DATABASE IS READY TO USE" --max-wait 600
 log "Oracle DB has started!"

--- a/connect/connect-cdc-xstream-oracle19-source/cdc-xstream-oracle19-mtls-wallet.sh
+++ b/connect/connect-cdc-xstream-oracle19-source/cdc-xstream-oracle19-mtls-wallet.sh
@@ -151,23 +151,17 @@ docker cp /tmp/cwallet.sso connect:/tmp/cwallet.sso
 playground container exec --root --command "chown appuser /tmp/cwallet.sso"
 
 # https://github.com/confluentinc/common-docker/pull/743 and https://github.com/adoptium/adoptium-support/issues/1285
-set +e
-playground container exec --root --command "sed -i "s/packages\.adoptium\.net/adoptium\.jfrog\.io/g" /etc/yum.repos.d/adoptium.repo"
-set -e
-playground container exec --root --command "microdnf -y install libaio"
-
-if [ "$(uname -m)" = "arm64" ]
-then
-     :
-else
-     if version_gt $TAG_BASE "7.9.9"
-     then
-          playground container exec --root --command "microdnf -y install libnsl2"
-          playground container exec --root --command "ln -s /usr/lib64/libnsl.so.3 /usr/lib64/libnsl.so.1"
-     else
-          playground container exec --root --command "ln -s /usr/lib64/libnsl.so.2 /usr/lib64/libnsl.so.1"
-     fi
-fi
+mkdir -p /tmp/xstream-libs
+docker run --rm -v /tmp/xstream-libs:/out --entrypoint sh redhat/ubi9-minimal:latest -c '
+  microdnf -y install libaio libnsl2 && \
+  cp -P /usr/lib64/libaio.so.* /usr/lib64/libnsl.so.* /usr/lib64/libtirpc.so.* \
+        /usr/lib64/libgssapi_krb5.so.* /usr/lib64/libkrb5.so.* /usr/lib64/libk5crypto.so.* \
+        /usr/lib64/libkrb5support.so.* /usr/lib64/libcom_err.so.* \
+        /usr/lib64/libkeyutils.so.* /out/
+'
+docker cp /tmp/xstream-libs/. connect:/usr/lib64/
+rm -rf /tmp/xstream-libs
+playground container exec --root --command "ldconfig && ln -sf /usr/lib64/libnsl.so.3 /usr/lib64/libnsl.so.1"
 
 playground container logs --container oracle --wait-for-log "DATABASE IS READY TO USE" --max-wait 600
 log "Oracle DB has started!"

--- a/connect/connect-cdc-xstream-oracle19-source/cdc-xstream-oracle19-ssl-wallet.sh
+++ b/connect/connect-cdc-xstream-oracle19-source/cdc-xstream-oracle19-ssl-wallet.sh
@@ -135,23 +135,17 @@ then
 fi
 
 # https://github.com/confluentinc/common-docker/pull/743 and https://github.com/adoptium/adoptium-support/issues/1285
-set +e
-playground container exec --root --command "sed -i "s/packages\.adoptium\.net/adoptium\.jfrog\.io/g" /etc/yum.repos.d/adoptium.repo"
-set -e
-playground container exec --root --command "microdnf -y install libaio"
-
-if [ "$(uname -m)" = "arm64" ]
-then
-     :
-else
-     if version_gt $TAG_BASE "7.9.9"
-     then
-          playground container exec --root --command "microdnf -y install libnsl2"
-          playground container exec --root --command "ln -s /usr/lib64/libnsl.so.3 /usr/lib64/libnsl.so.1"
-     else
-          playground container exec --root --command "ln -s /usr/lib64/libnsl.so.2 /usr/lib64/libnsl.so.1"
-     fi
-fi
+mkdir -p /tmp/xstream-libs
+docker run --rm -v /tmp/xstream-libs:/out --entrypoint sh redhat/ubi9-minimal:latest -c '
+  microdnf -y install libaio libnsl2 && \
+  cp -P /usr/lib64/libaio.so.* /usr/lib64/libnsl.so.* /usr/lib64/libtirpc.so.* \
+        /usr/lib64/libgssapi_krb5.so.* /usr/lib64/libkrb5.so.* /usr/lib64/libk5crypto.so.* \
+        /usr/lib64/libkrb5support.so.* /usr/lib64/libcom_err.so.* \
+        /usr/lib64/libkeyutils.so.* /out/
+'
+docker cp /tmp/xstream-libs/. connect:/usr/lib64/
+rm -rf /tmp/xstream-libs
+playground container exec --root --command "ldconfig && ln -sf /usr/lib64/libnsl.so.3 /usr/lib64/libnsl.so.1"
 
 playground container logs --container oracle --wait-for-log "DATABASE IS READY TO USE" --max-wait 600
 log "Oracle DB has started!"

--- a/connect/connect-cdc-xstream-oracle19-source/cdc-xstream-oracle19-ssl.sh
+++ b/connect/connect-cdc-xstream-oracle19-source/cdc-xstream-oracle19-ssl.sh
@@ -136,23 +136,17 @@ then
 fi
 
 # https://github.com/confluentinc/common-docker/pull/743 and https://github.com/adoptium/adoptium-support/issues/1285
-set +e
-playground container exec --root --command "sed -i "s/packages\.adoptium\.net/adoptium\.jfrog\.io/g" /etc/yum.repos.d/adoptium.repo"
-set -e
-playground container exec --root --command "microdnf -y install libaio"
-
-if [ "$(uname -m)" = "arm64" ]
-then
-     :
-else
-     if version_gt $TAG_BASE "7.9.9"
-     then
-          playground container exec --root --command "microdnf -y install libnsl2"
-          playground container exec --root --command "ln -s /usr/lib64/libnsl.so.3 /usr/lib64/libnsl.so.1"
-     else
-          playground container exec --root --command "ln -s /usr/lib64/libnsl.so.2 /usr/lib64/libnsl.so.1"
-     fi
-fi
+mkdir -p /tmp/xstream-libs
+docker run --rm -v /tmp/xstream-libs:/out --entrypoint sh redhat/ubi9-minimal:latest -c '
+  microdnf -y install libaio libnsl2 && \
+  cp -P /usr/lib64/libaio.so.* /usr/lib64/libnsl.so.* /usr/lib64/libtirpc.so.* \
+        /usr/lib64/libgssapi_krb5.so.* /usr/lib64/libkrb5.so.* /usr/lib64/libk5crypto.so.* \
+        /usr/lib64/libkrb5support.so.* /usr/lib64/libcom_err.so.* \
+        /usr/lib64/libkeyutils.so.* /out/
+'
+docker cp /tmp/xstream-libs/. connect:/usr/lib64/
+rm -rf /tmp/xstream-libs
+playground container exec --root --command "ldconfig && ln -sf /usr/lib64/libnsl.so.3 /usr/lib64/libnsl.so.1"
 
 playground container logs --container oracle --wait-for-log "DATABASE IS READY TO USE" --max-wait 600
 log "Oracle DB has started!"

--- a/connect/connect-cdc-xstream-oracle19-source/cdc-xstream-oracle19.sh
+++ b/connect/connect-cdc-xstream-oracle19-source/cdc-xstream-oracle19.sh
@@ -74,23 +74,17 @@ then
 fi
 
 # https://github.com/confluentinc/common-docker/pull/743 and https://github.com/adoptium/adoptium-support/issues/1285
-set +e
-playground container exec --root --command "sed -i "s/packages\.adoptium\.net/adoptium\.jfrog\.io/g" /etc/yum.repos.d/adoptium.repo"
-set -e
-playground container exec --root --command "microdnf -y install libaio"
-
-if [ "$(uname -m)" = "arm64" ]
-then
-     :
-else
-     if version_gt $TAG_BASE "7.9.9"
-     then
-          playground container exec --root --command "microdnf -y install libnsl2"
-          playground container exec --root --command "ln -s /usr/lib64/libnsl.so.3 /usr/lib64/libnsl.so.1"
-     else
-          playground container exec --root --command "ln -s /usr/lib64/libnsl.so.2 /usr/lib64/libnsl.so.1"
-     fi
-fi
+mkdir -p /tmp/xstream-libs
+docker run --rm -v /tmp/xstream-libs:/out --entrypoint sh redhat/ubi9-minimal:latest -c '
+  microdnf -y install libaio libnsl2 && \
+  cp -P /usr/lib64/libaio.so.* /usr/lib64/libnsl.so.* /usr/lib64/libtirpc.so.* \
+        /usr/lib64/libgssapi_krb5.so.* /usr/lib64/libkrb5.so.* /usr/lib64/libk5crypto.so.* \
+        /usr/lib64/libkrb5support.so.* /usr/lib64/libcom_err.so.* \
+        /usr/lib64/libkeyutils.so.* /out/
+'
+docker cp /tmp/xstream-libs/. connect:/usr/lib64/
+rm -rf /tmp/xstream-libs
+playground container exec --root --command "ldconfig && ln -sf /usr/lib64/libnsl.so.3 /usr/lib64/libnsl.so.1"
 
 playground container logs --container oracle --wait-for-log "DATABASE IS READY TO USE" --max-wait 600
 log "Oracle DB has started!"


### PR DESCRIPTION
This fixes the case where connect docker image does not have any package manager. Spawns a temp container, installs required packages and copies from there. Verified this works with 8.2.x and 7.9.x CP versions.