### PR TITLE
Fix UBI minimal build - change user

### DIFF
--- a/scripts/cli/playground
+++ b/scripts/cli/playground
@@ -10603,6 +10603,7 @@ FROM ${CP_CONNECT_IMAGE}:${CP_CONNECT_TAG}
 USER root
 COPY --from=pm / /
 RUN ldconfig
+USER appuser
 EOF
       DOCKER_BUILDKIT=0 docker build -t ${CP_CONNECT_IMAGE}:${CP_CONNECT_TAG} $pm_tmp_dir
       rm -rf $pm_tmp_dir

--- a/scripts/cli/src/lib/utils_function.sh
+++ b/scripts/cli/src/lib/utils_function.sh
@@ -284,6 +284,7 @@ FROM ${CP_CONNECT_IMAGE}:${CP_CONNECT_TAG}
 USER root
 COPY --from=pm / /
 RUN ldconfig
+USER appuser
 EOF
       DOCKER_BUILDKIT=0 docker build -t ${CP_CONNECT_IMAGE}:${CP_CONNECT_TAG} $pm_tmp_dir
       rm -rf $pm_tmp_dir


### PR DESCRIPTION
DynamoDB Sink connector test was failing due to wrong user after the image is built. The image originally is on APPUSER but the build switches to ROOT and does not change the user back.