### PR TITLE
Fix reproduction-models submodule pin and hdfs3-sink-hive4 docker build

### DIFF
--- a/connect/connect-hdfs3-sink/hdfs3-sink-hive4.sh
+++ b/connect/connect-hdfs3-sink/hdfs3-sink-hive4.sh
@@ -6,7 +6,7 @@ source ${DIR}/../../scripts/utils.sh
 
 log "Building Hadoop Docker image (replacing if exists)"
 cd ../../connect/connect-hdfs3-sink
-docker build -t kdp/hadoop:3.3.6 .
+docker build --load -t kdp/hadoop:3.3.6 .
 rm -f hadoop-config/hiveserver2.pid
 cd -
 


### PR DESCRIPTION
- Re-pin `reproduction-models` to `9b8765b9` (current head of kafka-docker-playground-internal). The pin `4bca39cb` on master was never pushed there, so `git clone --recursive` fails (`fatal: not our ref`) — this is breaking all runs of Confluent's CP validation pipeline since Jul 6. Same fix as #7780.
- `hdfs3-sink-hive4.sh`: `docker build --load` so the kdp/hadoop image lands in the daemon's image store on CI runners where the default builder is a container-driver buildx builder (no-op for the default docker builder).

Both validated green via Confluent's run-cp-connector-selected-tests pipeline against CP 8.0.x/8.2.x/8.3.x.