### PR TITLE
hdfs3-sink: query the sanitized hive table name in beeline

### DIFF
--- a/connect/connect-hdfs3-sink/hdfs3-sink.sh
+++ b/connect/connect-hdfs3-sink/hdfs3-sink.sh
@@ -87,8 +87,9 @@ then
 !connect jdbc:hive2://hive-server:10000/testhive
 hive
 hive
-show create table hdfs-topic;
-select * from hdfs-topic;
+-- the connector sanitizes the topic name when creating the hive table: hdfs-topic -> hdfs_topic
+show create table hdfs_topic;
+select * from hdfs_topic;
 EOF
   cat /tmp/result.log
   grep "value1" /tmp/result.log


### PR DESCRIPTION
Since the topic rename in f3bccde52 (`test_hdfs` → `hdfs-topic`), the hive-integration path of `hdfs3-sink.sh` (runs for connector < 2.0) always fails at the beeline check:

```
0: jdbc:hive2://hive-server:10000/testhive> show create table hdfs-topic;
Error: ParseException line 1:22 cannot recognize input near 'hdfs' '-' 'topic' in table name
```

Reproduced locally with `--connector-tag 1.2.22 --tag 8.0.0`. The connector itself handles the hyphen fine — it sanitizes the topic name when creating the hive table (`hdfs-topic` → `hdfs_topic`, verified: table exists and `select * from hdfs_topic` returns all records). Only the two beeline queries in the script reference the unsanitized name, which hive 3.1.2's parser rejects.

Fix: query `hdfs_topic` in beeline. **Topic name unchanged** — keeps the rfc naming from f3bccde52.

Fix verified locally

## Verification

Same configuration before and after (`playground run -f hdfs3-sink.sh --connector-tag 1.2.22 --tag 8.0.0`, KDP master, only this patch applied):

**Before** — fails at the beeline check:
```
0: jdbc:hive2://hive-server:10000/testhive> show create table hdfs-topic;
Error: Error while compiling statement: FAILED: ParseException line 1:22 cannot recognize input near 'hdfs' '-' 'topic' in table name (state=42000,code=40000)
🔥 RESULT: FAILURE for hdfs3-sink.sh (took: 3min 18sec)
```

**After** — with this patch:
```
0: jdbc:hive2://hive-server:10000/testhive> select * from hdfs_topic;
+----------------+-----------------------+
| hdfs_topic.f1  | hdfs_topic.partition  |
+----------------+-----------------------+
| value1         | 0                     |
...
| value9         | 0                     |
+----------------+-----------------------+
9 rows selected (1.75 seconds)
✅ RESULT: SUCCESS for hdfs3-sink.sh (took: 3min 7sec)
```

No impact on connector >= 2.0: the patched beeline block only runs for connector < 2.0, and hive 4 coverage comes from the separate `hdfs3-sink-hive4.sh` (untouched — verified locally: 3.0.15 on CP 8.0.0 → RESULT: SUCCESS, hive database and table created).
