### PR TITLE
github-source: point KDP test at owned repo instead of apache/kafka

### DIFF
--- a/connect/connect-github-source/github-source.sh
+++ b/connect/connect-github-source/github-source.sh
@@ -22,7 +22,7 @@ fi
 PLAYGROUND_ENVIRONMENT=${PLAYGROUND_ENVIRONMENT:-"plaintext"}
 playground start-environment --environment "${PLAYGROUND_ENVIRONMENT}" --docker-compose-override-file "${PWD}/docker-compose.plaintext.yml"
 
-if version_gt $CONNECTOR_TAG "1.9.9"
+if version_gt "${CONNECTOR_TAG:-9.9.9}" "1.9.9"
 then
      playground connector create-or-update --connector github-source  << EOF
 {
@@ -30,7 +30,7 @@ then
      "topic.name.pattern":"github-topic-\${resourceName}",
      "tasks.max": "1",
      "github.service.url":"https://api.github.com",
-     "github.repositories":"apache/kafka",
+     "github.repositories":"GHConnIT/kafka-connect-datagen",
      "github.resources":"stargazers",
      "github.since":"2019-01-01",
      "github.access.token": "$CONNECTOR_GITHUB_ACCESS_TOKEN",
@@ -53,7 +53,7 @@ else
      "topic.name.pattern":"github-topic-\${entityName}",
      "tasks.max": "1",
      "github.service.url":"https://api.github.com",
-     "github.repositories":"apache/kafka",
+     "github.repositories":"GHConnIT/kafka-connect-datagen",
      "github.tables":"stargazers",
      "github.since":"2019-01-01",
      "github.access.token": "$CONNECTOR_GITHUB_ACCESS_TOKEN",


### PR DESCRIPTION
Confluent's CI GitHub account used for KDP tests is enterprise-managed and cannot read stargazer data on external public repos (e.g. \`apache/kafka\`) -- only on repos it owns itself. This switches the test target to \`GHConnIT/kafka-connect-datagen\` (owned by that same account, already starred so the test's data-verification step has something to read).

Also fixes an unrelated bug: when \`CONNECTOR_TAG\` is unset, \`version_gt \$CONNECTOR_TAG "1.9.9"\` silently drops the empty argument and evaluates as \`version_gt "1.9.9"\`, which incorrectly takes the legacy/old connector-config branch. Defaulting to \`9.9.9\` when unset makes it correctly take the new-config branch instead.

Validated against the Confluent \`connect-ci-cd-pipelines\` CP-validation pipeline using this branch via \`KDP_REPO_OVERRIDE\`/\`KDP_BRANCH_OVERRIDE\` -- \`GithubSourceTest\` passes end-to-end.