### PR TITLE
Wait for manifest.json to exist before reading it after confluent-hub install

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -658,6 +658,22 @@ else
             # ls -1 | sort
             # cd - > /dev/null 2>&1
 
+            # For large connectors (many bundled jars), the install container can exit 0
+            # before the bind-mounted files are actually visible on the host. Wait for
+            # manifest.json to appear before reading it.
+            manifest_wait_path="${DIR_UTILS}/../confluent-hub/${connector_path}/manifest.json"
+            manifest_wait_attempts=0
+            while [ ! -f "$manifest_wait_path" ] && [ "$manifest_wait_attempts" -lt 30 ]
+            do
+              sleep 2
+              manifest_wait_attempts=$((manifest_wait_attempts+1))
+            done
+            if [ ! -f "$manifest_wait_path" ]
+            then
+              logerror "❌ $manifest_wait_path did not appear within 60s after confluent-hub install reported success"
+              exit 1
+            fi
+
             version=$(cat ${DIR_UTILS}/../confluent-hub/${connector_path}/manifest.json | jq -r '.version')
             release_date=$(cat ${DIR_UTILS}/../confluent-hub/${connector_path}/manifest.json | jq -r '.release_date')
             documentation_url=$(cat ${DIR_UTILS}/../confluent-hub/${connector_path}/manifest.json | jq -r '.documentation_url')


### PR DESCRIPTION
## Summary
For large connectors (many bundled jars, e.g. `kafka-connect-hdfs3` with ~330 jars), the `confluent-hub install` container can exit `0` before the bind-mounted files are actually visible on the host filesystem. This causes an intermittent race where the immediately-following `cat manifest.json` (used to determine the installed version, e.g. for the `--connector-jar` swap logic) fails with "No such file or directory" even though install succeeded.

## Fix
Poll for `manifest.json` to actually exist (up to 60s) before reading it, instead of trusting the install command's exit code alone.

## Testing
Reproduced and verified locally by running `playground run -f hdfs3-sink.sh --connector-jar <jar>` repeatedly — without the fix it failed at the jar-swap step; with the fix it consistently progresses past that step into full pipeline execution.
Also seeing the same in Confluent pipelines: https://semaphore.ci.confluent.io/branches/4b81cd32-8af5-41a7-b53e-16d8e874b698