### PR TITLE
pivotal-gemfire: docker build --load so image lands in daemon

### DIFF
--- a/connect/connect-pivotal-gemfire-sink/pivotal-gemfire-sink.sh
+++ b/connect/connect-pivotal-gemfire-sink/pivotal-gemfire-sink.sh
@@ -26,7 +26,7 @@ then
      log "Building pivotal-gemfire docker image..it can take a while..."
      OLDDIR=$PWD
      cd ${DIR}/docker-pivotal-gemfire
-     docker build --build-arg PIVOTAL_GEMFIRE_VERSION=9.15.1 -t pivotal-gemfire:latest .
+     docker build --load --build-arg PIVOTAL_GEMFIRE_VERSION=9.15.1 -t pivotal-gemfire:latest .
      cd ${OLDDIR}
 fi
 


### PR DESCRIPTION
## Problem

On CI runners that use the buildx `docker-container` driver, `docker build -t pivotal-gemfire:latest` in `connect/connect-pivotal-gemfire-sink/pivotal-gemfire-sink.sh` leaves the built image only in the build cache — it is never exported to the local Docker image store. The subsequent `docker compose` step then can't find `pivotal-gemfire:latest` locally and tries to pull it from a registry, which fails:

```
Image pivotal-gemfire:latest Pulling
Error: pull access denied for pivotal-gemfire, repository does not exist or may require 'docker login'
🔥 RESULT: FAILURE for pivotal-gemfire-sink.sh
```

This was observed running the test in the Confluent CP Connectors Validation pipeline against CP 8.3.x.

## Solution

Add `--load` to the `docker build` so the image is exported into the local Docker daemon's image store, making it available to `docker compose`. No effect on environments where the default builder already loads.

## Test Strategy

- [x] Validated via the CP selected-tests pipeline against CP 8.3.x (JDK 25) with this branch.

Note for maintainers: several other tests build helper images the same way (`amps`, `tibco`, `weblogic`) and may hit the same buildx-driver behavior on affected runners.
