### PR TITLE
Fix GCP_FIREBASE_REGION handling and support legacy us-central1 database URL

### DIFF
--- a/connect/connect-gcp-firebase-sink/README.md
+++ b/connect/connect-gcp-firebase-sink/README.md
@@ -57,6 +57,8 @@ Simply run:
 $ just use <playground run> command and search for gcp-firebase-source<use tab key to activate fzf completion (see https://kafka-docker-playground.io/#/cli?id=%e2%9a%a1-setup-completion), otherwise use full path, or correct relative path> .sh in this folder
 ```
 
+`gcp.firebase.database.reference` is built from `GCP_PROJECT` and the `GCP_FIREBASE_REGION` environment variable (defaults to `europe-west1`), e.g. `https://<GCP_PROJECT>-default-rtdb.<GCP_FIREBASE_REGION>.firebasedatabase.app/musicBlog`. Set `GCP_FIREBASE_REGION` to `us-central1` for legacy databases using the `https://<GCP_PROJECT>.firebaseio.com/musicBlog` format instead.
+
 ### Verify data has been pushed to Firebase
 
 Note: this is now automated.

--- a/connect/connect-gcp-firebase-sink/gcp-firebase-sink.sh
+++ b/connect/connect-gcp-firebase-sink/gcp-firebase-sink.sh
@@ -17,7 +17,13 @@ then
      exit 1
 fi
 
-GCP_FIREBASE_REGION=${1:-europe-west1}
+GCP_FIREBASE_REGION=${GCP_FIREBASE_REGION:-europe-west1}
+if [ "$GCP_FIREBASE_REGION" == "us-central1" ]
+then
+     GCP_FIREBASE_DATABASE_REFERENCE="https://${GCP_PROJECT}.firebaseio.com/musicBlog"
+else
+     GCP_FIREBASE_DATABASE_REFERENCE="https://${GCP_PROJECT}-default-rtdb.${GCP_FIREBASE_REGION}.firebasedatabase.app/musicBlog"
+fi
 
 cd ../../connect/connect-gcp-firebase-sink
 GCP_KEYFILE="${PWD}/keyfile.json"
@@ -49,7 +55,7 @@ playground connector create-or-update --connector firebase-sink  << EOF
   "tasks.max" : "1",
   "topics":"artists,songs",
   "gcp.firebase.credentials.path": "/tmp/keyfile.json",
-  "gcp.firebase.database.reference": "https://${GCP_PROJECT}-default-rtdb.${GCP_FIREBASE_REGION}.firebasedatabase.app/musicBlog",
+  "gcp.firebase.database.reference": "${GCP_FIREBASE_DATABASE_REFERENCE}",
   "insert.mode":"update",
   "key.converter": "org.apache.kafka.connect.storage.StringConverter",
   "value.converter" : "io.confluent.connect.avro.AvroConverter",

--- a/connect/connect-gcp-firebase-source/README.md
+++ b/connect/connect-gcp-firebase-source/README.md
@@ -69,3 +69,5 @@ Simply run:
 ```bash
 $ just use <playground run> command and search for gcp-firebase-source<use tab key to activate fzf completion (see https://kafka-docker-playground.io/#/cli?id=%e2%9a%a1-setup-completion), otherwise use full path, or correct relative path> .sh in this folder
 ```
+
+`gcp.firebase.database.reference` is built from `GCP_PROJECT` and the `GCP_FIREBASE_REGION` environment variable (defaults to `europe-west1`), e.g. `https://<GCP_PROJECT>-default-rtdb.<GCP_FIREBASE_REGION>.firebasedatabase.app/musicBlog`. Set `GCP_FIREBASE_REGION` to `us-central1` for legacy databases using the `https://<GCP_PROJECT>.firebaseio.com/musicBlog` format instead.

--- a/connect/connect-gcp-firebase-source/gcp-firebase-source.sh
+++ b/connect/connect-gcp-firebase-source/gcp-firebase-source.sh
@@ -34,8 +34,13 @@ else
 fi
 cd -
 
-GCP_FIREBASE_REGION=${1:-europe-west1}
-
+GCP_FIREBASE_REGION=${GCP_FIREBASE_REGION:-europe-west1}
+if [ "$GCP_FIREBASE_REGION" == "us-central1" ]
+then
+     GCP_FIREBASE_DATABASE_REFERENCE="https://${GCP_PROJECT}.firebaseio.com/musicBlog"
+else
+     GCP_FIREBASE_DATABASE_REFERENCE="https://${GCP_PROJECT}-default-rtdb.${GCP_FIREBASE_REGION}.firebasedatabase.app/musicBlog"
+fi
 
 log "Removing all data"
 docker run -p 9005:9005 -v $PWD/../../connect/connect-gcp-firebase-source/keyfile.json:/tmp/keyfile.json -e GOOGLE_APPLICATION_CREDENTIALS="/tmp/keyfile.json" -e PROJECT=$GCP_PROJECT -i andreysenov/firebase-tools firebase database:remove / --project "$GCP_PROJECT" --force
@@ -53,7 +58,7 @@ playground connector create-or-update --connector firebase-source  << EOF
     "connector.class" : "io.confluent.connect.firebase.FirebaseSourceConnector",
     "tasks.max" : "1",
     "gcp.firebase.credentials.path": "/tmp/keyfile.json",
-    "gcp.firebase.database.reference": "https://${GCP_PROJECT}-default-rtdb.${GCP_FIREBASE_REGION}.firebasedatabase.app/musicBlog",
+    "gcp.firebase.database.reference": "${GCP_FIREBASE_DATABASE_REFERENCE}",
     "gcp.firebase.snapshot":"true",
     "confluent.topic.bootstrap.servers": "broker:9092",
     "confluent.topic.replication.factor": "1",


### PR DESCRIPTION
## Summary
- `GCP_FIREBASE_REGION=${1:-europe-west1}` read the script's positional argument `$1`, not the `GCP_FIREBASE_REGION` environment variable of the same name, so the region was always silently hardcoded to `europe-west1` regardless of any exported `GCP_FIREBASE_REGION`. Fixed to `GCP_FIREBASE_REGION=${GCP_FIREBASE_REGION:-europe-west1}` so the env var is actually respected.
- `gcp.firebase.database.reference` is now built from `GCP_PROJECT` and the region: `us-central1` databases use the legacy `https://<project>.firebaseio.com/musicBlog` format, other regions use `https://<project>-default-rtdb.<region>.firebasedatabase.app/musicBlog`.
- Updated both READMEs to document `GCP_FIREBASE_REGION`.

Applies to both `connect/connect-gcp-firebase-source/gcp-firebase-source.sh` and `connect/connect-gcp-firebase-sink/gcp-firebase-sink.sh`.
