### PR TITLE
Added tag to the subscription name

### DIFF
--- a/connect/connect-gcp-pubsub-source/gcp-pubsub-source.sh
+++ b/connect/connect-gcp-pubsub-source/gcp-pubsub-source.sh
@@ -43,8 +43,15 @@ docker rm -f gcloud-config
 set -e
 docker run -i -v ${GCP_KEYFILE}:/tmp/keyfile.json --name gcloud-config google/cloud-sdk:latest gcloud auth activate-service-account --project ${GCP_PROJECT} --key-file /tmp/keyfile.json
 
-GCP_PUB_SUB_TOPIC="topic-1-$GITHUB_RUN_NUMBER"
-GCP_PUB_SUB_SUBSCRIPTION="subscription-1-$GITHUB_RUN_NUMBER"
+if [ ! -z "$TAG" ]
+then
+     SUFFIX="$TAG"
+else
+     SUFFIX="$GITHUB_RUN_NUMBER"
+fi
+
+GCP_PUB_SUB_TOPIC="topic-1-$SUFFIX"
+GCP_PUB_SUB_SUBSCRIPTION="subscription-1-$SUFFIX"
 
 # cleanup if required
 set +e


### PR DESCRIPTION
### Problem 
We were using $GITHUB_RUN_NUMBER as a suffix in topic and subscription. So whenever we run some tests in parallel for different CP tags the tests gets failed due to the cleanup we are doing on a resource. 

### Solution 
Use $TAG if present, otherwise rely on $GITHUB_RUN_NUMBER