### PR TITLE
CC-42934: Skip connect readiness wait when starting services without connect

### DIFF
--- a/scripts/cli/playground
+++ b/scripts/cli/playground
@@ -12483,6 +12483,14 @@ function wait_container_ready() {
   CONTROL_CENTER_CONTAINER=${2:-"control-center"}
   MAX_WAIT=300
 
+  if [[ -n "$START_SERVICES" ]] \
+     && [[ ! " $START_SERVICES " == *" ${CONNECT_CONTAINER}"* ]] \
+     && [[ ! " $START_SERVICES " == *" ${CONTROL_CENTER_CONTAINER}"* ]]
+  then
+    log "🔍 Skipping readiness wait: START_SERVICES='${START_SERVICES}' does not include ${CONNECT_CONTAINER} or ${CONTROL_CENTER_CONTAINER}"
+    return
+  fi
+
   if [[ "$PLAYGROUND_ENVIRONMENT" == "cfk" ]]
   then
     if [ ! -z $WAIT_FOR_CONTROL_CENTER ]

--- a/scripts/cli/src/lib/utils_function.sh
+++ b/scripts/cli/src/lib/utils_function.sh
@@ -1202,6 +1202,14 @@ function wait_container_ready() {
   CONTROL_CENTER_CONTAINER=${2:-"control-center"}
   MAX_WAIT=300
 
+  if [[ -n "$START_SERVICES" ]] \
+     && [[ ! " $START_SERVICES " == *" ${CONNECT_CONTAINER}"* ]] \
+     && [[ ! " $START_SERVICES " == *" ${CONTROL_CENTER_CONTAINER}"* ]]
+  then
+    log "🔍 Skipping readiness wait: START_SERVICES='${START_SERVICES}' does not include ${CONNECT_CONTAINER} or ${CONTROL_CENTER_CONTAINER}"
+    return
+  fi
+
   if [[ "$PLAYGROUND_ENVIRONMENT" == "cfk" ]]
   then
     if [ ! -z $WAIT_FOR_CONTROL_CENTER ]


### PR DESCRIPTION
## Problem

The selective service startup feature (`START_SERVICES` / `playground start-environment --service <svc>`) broke tests [here](https://semaphore.ci.confluent.io/workflows/df776aea-ffec-4983-8bea-bd38fd83daab?pipeline_id=b81707ed-76a9-47fd-8a9a-2adc24a7058e). These tests start only the database container first.

`wait_container_ready` unconditionally waits for the connect REST API, so the oracle-only startup step fails almost immediately:
```
❌ No available port found for connect rest api, none of containers connect, connect2 or connect3 are running!
RESULT: FAILURE (took: 0min 16sec)
```

## Fix

Guard `wait_container_ready`: when `START_SERVICES` is set and includes neither the connect container nor control-center, log and return.

## Testing

Oracle tests are passing now - [ref](https://semaphore.ci.confluent.io/workflows/5ee9636d-2d8d-4f29-bf42-5c47c5f471fe?pipeline_id=2b732e81-9229-438f-9df5-ed91cba8d389)