### PR TITLE
[MINOR] Reorder connect-transforms first on CONNECT_PLUGIN_PATH for SMT PR gating

### DIFF
--- a/connect/connect-testing-smt/docker-compose.plaintext.datagen.transforms.yml
+++ b/connect/connect-testing-smt/docker-compose.plaintext.datagen.transforms.yml
@@ -6,6 +6,8 @@ services:
       # datagen schemas used as a structured source so the (renamed) output topic can be consumed
       - ../../connect/connect-testing-smt/schemas:/tmp/schemas
     environment:
-      # datagen source carrier FIRST, then the Confluent connect-transforms component that provides
-      # the io.confluent.connect.transforms.* SMTs (needed by the Confluent routing scripts)
-      CONNECT_PLUGIN_PATH: /usr/share/confluent-hub-components/confluentinc-kafka-connect-datagen,/usr/share/confluent-hub-components/confluentinc-connect-transforms
+      # The connector under test (connect-transforms) MUST be listed first: for
+      # PR testing, connect-ci-cd injects the PR-built artifact (CONNECTOR_ZIP /
+      # CONNECTOR_JAR) and KDP applies it only to the first plugin on the path.
+      # The datagen source is just the carrier and is installed from Confluent Hub.
+      CONNECT_PLUGIN_PATH: /usr/share/confluent-hub-components/confluentinc-connect-transforms,/usr/share/confluent-hub-components/confluentinc-kafka-connect-datagen


### PR DESCRIPTION
## What

In `connect/connect-testing-smt/docker-compose.plaintext.datagen.transforms.yml`, reorder `CONNECT_PLUGIN_PATH` so `confluentinc-connect-transforms` is listed **before** `confluentinc-kafka-connect-datagen`, and update the accompanying comment.

## Why

This override is used by the two Confluent SMT scripts that run on a datagen source - `drop.sh` (`Drop`) and `extracttopic.sh` (`ExtractTopic`).

For PR gating, `connect-ci-cd-pipelines` injects the PR-built artifact via `CONNECTOR_ZIP` / `CONNECTOR_JAR`, and KDP applies it **only to the first plugin** on `CONNECT_PLUGIN_PATH` (the `first_loop` branch in `scripts/utils.sh`). With **datagen listed first**:

- the PR-built connect-transforms artifact would be tied to the first slot (datagen),
- datagen would then be skipped from its Hub install → the datagen **source connector is missing**, so `drop.sh` / `extracttopic.sh` fail to even start, and
- connect-transforms would be (re)installed from the Hub at the released version, so the PR changes are never actually exercised.

Putting **connect-transforms first** fixes this: the PR artifact is applied to connect-transforms, and datagen is installed from Confluent Hub as the second plugin. The carrier order has no effect on normal (non-PR) runs.

## Impact

- No behavior change for normal runs of any SMT test.
- Enables `drop.sh` and `extracttopic.sh` to correctly gate `connect-transforms` PRs (paired with the connect-ci-cd-pipelines mapping entries).