### PR TITLE
Add connect-appdynamics-metrics-sink to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
                       "🚀 connect/connect-gcp-pubsub-source connect/connect-gcp-google-pubsub-source connect/connect-gcp-google-pubsub-sink connect/connect-gcp-gcs-sink connect/connect-gcp-gcs-source connect/connect-gcp-bigtable-sink connect/connect-kudu-sink",
                       "🚀 connect/connect-azure-data-lake-storage-gen2-sink connect/connect-azure-event-hubs-source connect/connect-azure-cognitive-search-sink connect/connect-azure-functions-sink connect/connect-azure-service-bus-source connect/connect-azure-blob-storage-source",
                       "🚀 connect/connect-rabbitmq-sink connect/connect-jira-source connect/connect-github-source connect/connect-pivotal-gemfire-sink connect/connect-azure-blob-storage-sink connect/connect-azure-synapse-analytics-sink connect/connect-jdbc-azure-synapse-analytics-source",
-                      "🚀 connect/connect-http-sink connect/connect-iceberg-sink connect/connect-clickhouse-sink connect/connect-testing-smt",
+                      "🚀 connect/connect-http-sink connect/connect-iceberg-sink connect/connect-clickhouse-sink connect/connect-testing-smt connect/connect-appdynamics-metrics-sink",
                       "🚀 multi-data-center/replicator-connect",
                       "🚀 multi-data-center/replicator-executable",
                       "🚀 multi-data-center/mirrormaker2 connect/connect-pagerduty-sink connect/connect-zendesk-source connect/connect-datadog-metrics-sink connect/connect-gcp-spanner-sink connect/connect-gcp-firebase-source connect/connect-gcp-firebase-sink",


### PR DESCRIPTION
## Summary
This adds connect/connect-appdynamics-metrics-sink to an existing connect/ bucket so `appdynamics-metrics-sink.sh` is picked up by run-tests.sh and covered on the nightly schedule.