### PR TITLE
Add connect-http-source to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
                       "🚀 connect/connect-gcp-bigquery-sink connect-jdbc-gcp-bigquery-source connect/connect-gcp-cloud-functions-sink connect/connect-vertica-sink connect/connect-prometheus-sink connect/connect-aws-sqs-source connect/connect-aws-s3-sink connect/connect-aws-s3-source connect/connect-databricks-delta-lake-sink",
                       "🚀 connect/connect-gcp-pubsub-source connect/connect-gcp-google-pubsub-source connect/connect-gcp-google-pubsub-sink connect/connect-gcp-gcs-sink connect/connect-gcp-gcs-source connect/connect-gcp-bigtable-sink connect/connect-kudu-sink",
                       "🚀 connect/connect-azure-data-lake-storage-gen2-sink connect/connect-azure-event-hubs-source connect/connect-azure-cognitive-search-sink connect/connect-azure-functions-sink connect/connect-azure-service-bus-source connect/connect-azure-blob-storage-source",
-                      "🚀 connect/connect-rabbitmq-sink connect/connect-jira-source connect/connect-github-source connect/connect-pivotal-gemfire-sink connect/connect-azure-blob-storage-sink connect/connect-azure-synapse-analytics-sink connect/connect-jdbc-azure-synapse-analytics-source",
+                      "🚀 connect/connect-rabbitmq-sink connect/connect-jira-source connect/connect-github-source connect/connect-pivotal-gemfire-sink connect/connect-azure-blob-storage-sink connect/connect-azure-synapse-analytics-sink connect/connect-jdbc-azure-synapse-analytics-source connect/connect-http-source",
                       "🚀 connect/connect-http-sink connect/connect-iceberg-sink connect/connect-clickhouse-sink connect/connect-testing-smt",
                       "🚀 multi-data-center/replicator-connect",
                       "🚀 multi-data-center/replicator-executable",


### PR DESCRIPTION
## Summary
This adds connect/connect-http-source to an existing connect/ bucket so `http-source-*.sh` tests are picked up by run-tests.sh and covered on the nightly schedule.

This connector has never been executed as part of the KDP pipeline — it is not in the ci.yml test matrix, and across the full history plus all workflow_dispatch runs there have been zero executions.