### PR TITLE
Salesforce: log out at end of test, and stop re-authenticating in cleanup

### DIFF
--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source.sh
@@ -92,11 +92,6 @@ playground container exec --container sfdx-cli --command "sfdx data:create:recor
 cleanup_salesforce_test_data() {
   set +e
   log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME (both orgs) and PushTopic $PUSH_TOPICS_NAME"
-  # Re-authenticate both orgs first: the connectors log in as the same users with
-  # the username-password grant, which makes Salesforce evict the sfdx CLI session
-  # ("Session expired or invalid"), so the earlier sfdx logins may no longer work.
-  playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\"" --shell sh > /dev/null
-  playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME_ACCOUNT2\" -p \"$SALESFORCE_PASSWORD_ACCOUNT2\" -r \"$SALESFORCE_INSTANCE_ACCOUNT2\" -s \"$SALESFORCE_SECURITY_TOKEN_ACCOUNT2\"" --shell sh > /dev/null
   playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" --shell sh << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
@@ -104,6 +99,11 @@ EOF
   playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" --shell sh << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 EOF
+  # Release the session(s) this test opened. Each sfpowerkit:auth:login creates two
+  # Salesforce sessions, and without a logout they are left to expire - so a run
+  # accumulates sessions against the same user and later logins evict earlier ones
+  # ("Session expired or invalid").
+  playground container exec --container sfdx-cli --command "sfdx force:auth:logout --all --no-prompt" --shell sh > /dev/null
   set -e
 }
 trap cleanup_salesforce_test_data EXIT

--- a/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source.sh
+++ b/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source.sh
@@ -53,14 +53,14 @@ playground container exec --container sfdx-cli --command "sfdx data:create:recor
 cleanup_salesforce_test_data() {
   set +e
   log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME"
-  # Re-authenticate first: the connector logs in as the same user with the
-  # username-password grant, which makes Salesforce evict the sfdx CLI session
-  # ("Session expired or invalid"), so the sfdx login done earlier may no longer
-  # be usable by the time this runs.
-  playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\"" --shell sh > /dev/null
   playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" --shell sh << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 EOF
+  # Release the session(s) this test opened. Each sfpowerkit:auth:login creates two
+  # Salesforce sessions, and without a logout they are left to expire - so a run
+  # accumulates sessions against the same user and later logins evict earlier ones
+  # ("Session expired or invalid").
+  playground container exec --container sfdx-cli --command "sfdx force:auth:logout --all --no-prompt" --shell sh > /dev/null
   set -e
 }
 trap cleanup_salesforce_test_data EXIT

--- a/connect/connect-salesforce-cdc-source/salesforce-cdc-source.sh
+++ b/connect/connect-salesforce-cdc-source/salesforce-cdc-source.sh
@@ -106,6 +106,11 @@ cleanup_salesforce_test_data() {
   playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" --shell sh << EOF
 Database.delete([SELECT Id FROM Contact WHERE FirstName = '$CONTACT_FIRSTNAME' AND LastName = '$CONTACT_LASTNAME'], false);
 EOF
+  # Release the session(s) this test opened. Each sfpowerkit:auth:login creates two
+  # Salesforce sessions, and without a logout they are left to expire - so a run
+  # accumulates sessions against the same user and later logins evict earlier ones
+  # ("Session expired or invalid").
+  playground container exec --container sfdx-cli --command "sfdx force:auth:logout --all --no-prompt" --shell sh > /dev/null
   set -e
 }
 trap cleanup_salesforce_test_data EXIT

--- a/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source.sh
+++ b/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source.sh
@@ -120,6 +120,11 @@ cleanup_salesforce_test_data() {
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
 EOF
+  # Release the session(s) this test opened. Each sfpowerkit:auth:login creates two
+  # Salesforce sessions, and without a logout they are left to expire - so a run
+  # accumulates sessions against the same user and later logins evict earlier ones
+  # ("Session expired or invalid").
+  playground container exec --container sfdx-cli --command "sfdx force:auth:logout --all --no-prompt" --shell sh > /dev/null
   set -e
 }
 trap cleanup_salesforce_test_data EXIT

--- a/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink.sh
+++ b/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink.sh
@@ -151,10 +151,6 @@ playground container exec --container sfdx-cli --command "sfdx data:create:recor
 cleanup_salesforce_test_data() {
   set +e
   log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME (both orgs) and PushTopic $PUSH_TOPICS_NAME"
-  # Re-authenticate both orgs first, so cleanup does not depend on an sfdx session
-  # established earlier in the test still being valid.
-  playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\"" --shell sh > /dev/null
-  playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME_ACCOUNT2\" -p \"$SALESFORCE_PASSWORD_ACCOUNT2\" -r \"$SALESFORCE_INSTANCE_ACCOUNT2\" -s \"$SALESFORCE_SECURITY_TOKEN_ACCOUNT2\"" --shell sh > /dev/null
   playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" --shell sh << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
@@ -162,6 +158,11 @@ EOF
   playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" --shell sh << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 EOF
+  # Release the session(s) this test opened. Each sfpowerkit:auth:login creates two
+  # Salesforce sessions, and without a logout they are left to expire - so a run
+  # accumulates sessions against the same user and later logins evict earlier ones
+  # ("Session expired or invalid").
+  playground container exec --container sfdx-cli --command "sfdx force:auth:logout --all --no-prompt" --shell sh > /dev/null
   set -e
 }
 trap cleanup_salesforce_test_data EXIT


### PR DESCRIPTION
Follow-up to #8716 — this **corrects a regression I introduced there**, and adds the logout
step the Salesforce tests have never had.

## 1. The cleanup re-auth in #8716 doubled session usage

Salesforce Login History shows that each `sfdx sfpowerkit:auth:login` creates **two**
sessions — paired SOAP Partner logins at API 52.0 and 64.0, seconds apart:

```
10:08:11  Other Apex API  SOAP Partner 52.0  ┐ login #1
10:08:12  Other Apex API  SOAP Partner 64.0  ┘
10:08:15  Other Apex API  SOAP Partner 52.0  ┐ login #2
10:08:16  Other Apex API  SOAP Partner 64.0  ┘
...
```

The cleanup functions I added in #8716 re-authenticated each org before deleting, which
doubled the logins per test — taking `salesforce-bulkapi-sink-with-bulkapi-source` and
`salesforce-sobject-sink` from 4 sessions to **8** against a single user. Sessions then
evicted one another, and tests failed partway through with `Session expired or invalid` and
`Bad_OAuth_Token`, always in the `sfdx` steps while the connectors themselves were healthy
and `RUNNING`.

That re-auth was simply the wrong fix. The local failure that prompted it was *itself*
session exhaustion, so responding with more logins made things worse. Removed from every
cleanup function, restoring the upstream count of one login per org.

## 2. No Salesforce test has ever logged out

Every run abandoned its sessions to expire. Added to each cleanup function:

```bash
sfdx force:auth:logout --all --no-prompt
```

Cleanup is registered as an `EXIT` trap, so this also runs when a test fails — which is
precisely when a test would otherwise leak sessions. `--all` is appropriate because the
`sfdx-cli` container is torn down per test anyway.

Net effect:

| Test | logins before | after | sessions released |
|---|---|---|---|
| `salesforce-cdc-source` | 1 | 1 | ✅ |
| `salesforce-pushtopic-source` | 1 | 1 | ✅ |
| `salesforce-bulkapi-source` | 2 | 1 | ✅ |
| `salesforce-bulkapi-sink-with-bulkapi-source` | 4 | 2 | ✅ |
| `salesforce-sobject-sink` | 4 | 2 | ✅ |

## Testing

CP 7.9.0, against a shared Developer Edition org:

```
salesforce-cdc-source.sh                        SUCCESS   cleanup: Executed successfully
salesforce-bulkapi-sink-with-bulkapi-source.sh  SUCCESS   cleanup: Executed successfully
salesforce-sobject-sink.sh                      SUCCESS   cleanup: Executed successfully (both orgs)
```

## Known limitation, stated plainly

`salesforce-bulkapi-sink-with-bulkapi-source`'s cleanup of the **source** org can still emit
`Session expired or invalid` before succeeding on the other org. That test's connectors
authenticate with the **username-password** grant as the same user, so they can evict the
sfdx session mid-test. Cleanup runs under `set +e`, so the test still passes and the second
org's delete still happens, but a Lead may occasionally be left behind.

The proper fix is to retry the delete after re-authenticating **only when it fails**, rather
than re-authenticating unconditionally as #8716 did. I have deliberately not added that here
to keep the change small — happy to include it if you would prefer.

Related: the connectors in that test still use the username-password grant, which Salesforce
is retiring (#8666 migrated the other examples to JWT). Moving `bulkapi-source`/`bulkapi-sink`
to JWT would remove this class of problem entirely, since the JWT logins in Login History
(`Remote Access 2.0`) have never contended with the sfdx sessions.
