### PR TITLE
fix: close stdin for Solace CLI exec so tests don't hang under piped stdin

### DIFF
--- a/connect/connect-solace-sink/solace-sink.sh
+++ b/connect/connect-solace-sink/solace-sink.sh
@@ -22,7 +22,7 @@ then
 fi
 
 function wait_for_solace () {
-     MAX_WAIT=240
+     MAX_WAIT=600
      log "⌛ Waiting up to $MAX_WAIT seconds for Solace to startup"
      # Use playground logs so readiness wait works for both Docker and CFK environments.
      playground container logs --container solace --wait-for-log "Running pre-startup checks" --max-wait "$MAX_WAIT"
@@ -78,6 +78,6 @@ EOF
 sleep 30
 
 log "Confirm the messages were delivered to the connector-quickstart queue in the default Message VPN using CLI"
-playground container exec --container solace --command "bash -c \"/usr/sw/loads/currentload/bin/cli -A -s cliscripts/show_queue_cmd\"" > /tmp/result.log  2>&1
+run_solace_cli_script_with_retry "show_queue_cmd" "queue stats check" "/tmp/result.log"
 cat /tmp/result.log
 grep "10       0.00" /tmp/result.log

--- a/connect/connect-solace-source/solace-source.sh
+++ b/connect/connect-solace-source/solace-source.sh
@@ -22,7 +22,7 @@ then
 fi
 
 function wait_for_solace () {
-     MAX_WAIT=240
+     MAX_WAIT=600
      log "⌛ Waiting up to $MAX_WAIT seconds for Solace to startup"
      # Use playground logs so readiness wait works for both Docker and CFK environments.
      playground container logs --container solace --wait-for-log "Running pre-startup checks" --max-wait "$MAX_WAIT"
@@ -52,7 +52,7 @@ wait_for_solace
 log "Solace UI is accessible at http://127.0.0.1:8080 (admin/admin)"
 
 log "Create the queue connector-quickstart in the default Message VPN using CLI"
-playground container exec --container solace --command "bash -c \"/usr/sw/loads/currentload/bin/cli -A -s cliscripts/create_queue_cmd\""
+run_solace_cli_script_with_retry "create_queue_cmd" "queue creation"
 
 # Setting message.timestamp.type=LogAppendTime otherwise we have CreateTime:0
 playground topic create --topic from-solace-messages --nb-partitions 1

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -36,6 +36,44 @@ function install_connector_with_retry {
   return 1
 }
 
+function run_solace_cli_script_with_retry {
+  local script_name="$1"
+  local description="$2"
+  local output_file="${3:-/tmp/solace-cli-${script_name}.log}"
+  local max_wait=${SOLACE_CLI_MAX_WAIT:-300}
+  local attempt_timeout=${SOLACE_CLI_ATTEMPT_TIMEOUT:-60}
+  local cur_wait=0
+
+  log "⌛ Waiting up to $max_wait seconds for Solace CLI to be ready for ${description}"
+  while true
+  do
+    set +e
+    timeout "$attempt_timeout" playground container exec --container solace --command "bash -c \"/usr/sw/loads/currentload/bin/cli -A -s cliscripts/${script_name}\"" > "$output_file" 2>&1
+    local ret=$?
+    set -e
+
+    if [ "$ret" -eq 0 ]
+    then
+      log "Solace CLI is ready for ${description}"
+      return 0
+    fi
+
+    if [ "$ret" -eq 124 ]
+    then
+      logwarn "Solace CLI did not respond within ${attempt_timeout}s for ${description}, retrying... (${cur_wait}/${max_wait}s)"
+    fi
+
+    sleep 10
+    cur_wait=$((cur_wait + 10))
+    if [ "$cur_wait" -gt "$max_wait" ]
+    then
+      logerror "Solace CLI is not ready for ${description} after ${max_wait} seconds"
+      cat "$output_file"
+      exit 1
+    fi
+  done
+}
+
 function cleanup-workaround-file {
   rm -f /tmp/without-cli-workaround > /dev/null 2>&1
 }

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -48,7 +48,7 @@ function run_solace_cli_script_with_retry {
   while true
   do
     set +e
-    timeout "$attempt_timeout" playground container exec --container solace --command "bash -c \"/usr/sw/loads/currentload/bin/cli -A -s cliscripts/${script_name}\"" > "$output_file" 2>&1
+    timeout "$attempt_timeout" playground container exec --container solace --command "bash -c \"/usr/sw/loads/currentload/bin/cli -A -s cliscripts/${script_name}\"" > "$output_file" 2>&1 < /dev/null
     local ret=$?
     set -e
 


### PR DESCRIPTION
## Problem

Both `connect-solace` tests hang forever on CP 8.3 at the CLI call — `solace-source.sh:55` (`create_queue_cmd`), `solace-sink.sh:81` (`show_queue_cmd`).

## Cause

`playground container exec` uses `docker exec -i`, which forwards the caller's stdin. Confluent's CP pipeline runs tests as `yes | playground run -f …`, so `cli -A -s` gets an endless `y` stream and never sees EOF.

Solace is the only family here that execs an interactive CLI, and this repo's CI doesn't use `yes |` — hence green upstream, hung for us.

Not readiness: with a 60s per-attempt timeout, **31 consecutive attempts all exited 124** over 35 minutes.

## Change

- **`< /dev/null` on the CLI exec** — the fix
- Restore `run_solace_cli_script_with_retry` (removed in `cb841990`) with a per-attempt `timeout`, in `scripts/utils.sh`
- `MAX_WAIT` back to 600

Validated on CP 8.3.x, both tests pass: [workflow a6799dcb](https://semaphore.ci.confluent.io/workflows/a6799dcb-3b1c-479f-b848-664c125a3853)
