### PR TITLE
Salesforce: fix the cross-org Lead lookup, and drop the no-op sfdx logout

### DIFF
--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source-proxy.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source-proxy.sh
@@ -166,6 +166,12 @@ log "Login with sfdx CLI on the account #2"
 playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME_ACCOUNT2\" -p \"$SALESFORCE_PASSWORD_ACCOUNT2\" -r \"$SALESFORCE_INSTANCE_ACCOUNT2\" -s \"$SALESFORCE_SECURITY_TOKEN_ACCOUNT2\"" --shell sh
 
 log "Get the Lead created on account #2"
-playground container exec --container sfdx-cli --command "sfdx data:record:get --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -s Lead -w \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\"" --shell sh > /tmp/result.log  2>&1
+# data:query, not data:record:get: the sink inserts (it never upserts), so a shared org
+# accumulates Leads and an aborted run can leave one behind. data:record:get then fails
+# with "is not a unique qualifier for Lead; N records were retrieved" even though the
+# record the test just wrote is present. data:query returns every match, and the grep
+# below still fails if the record is genuinely missing.
+# || true so cat always runs - without it set -e aborts here and the error is never shown.
+playground container exec --container sfdx-cli --command "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" --shell sh > /tmp/result.log 2>&1 || true
 cat /tmp/result.log
 grep "$LEAD_FIRSTNAME" /tmp/result.log

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source.sh
@@ -99,11 +99,6 @@ EOF
   playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" --shell sh << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 EOF
-  # Release the session(s) this test opened. Each sfpowerkit:auth:login creates two
-  # Salesforce sessions, and without a logout they are left to expire - so a run
-  # accumulates sessions against the same user and later logins evict earlier ones
-  # ("Session expired or invalid").
-  playground container exec --container sfdx-cli --command "sfdx force:auth:logout --all --no-prompt" --shell sh > /dev/null
   set -e
 }
 trap cleanup_salesforce_test_data EXIT

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source.sh
@@ -246,6 +246,12 @@ log "Login with sfdx CLI on the account #2"
 playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME_ACCOUNT2\" -p \"$SALESFORCE_PASSWORD_ACCOUNT2\" -r \"$SALESFORCE_INSTANCE_ACCOUNT2\" -s \"$SALESFORCE_SECURITY_TOKEN_ACCOUNT2\"" --shell sh
 
 log "Get the Lead created on account #2"
-playground container exec --container sfdx-cli --command "sfdx data:record:get --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -s Lead -w \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\"" --shell sh > /tmp/result.log  2>&1
+# data:query, not data:record:get: the sink inserts (it never upserts), so a shared org
+# accumulates Leads and an aborted run can leave one behind. data:record:get then fails
+# with "is not a unique qualifier for Lead; N records were retrieved" even though the
+# record the test just wrote is present. data:query returns every match, and the grep
+# below still fails if the record is genuinely missing.
+# || true so cat always runs - without it set -e aborts here and the error is never shown.
+playground container exec --container sfdx-cli --command "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" --shell sh > /tmp/result.log 2>&1 || true
 cat /tmp/result.log
 grep "$LEAD_FIRSTNAME" /tmp/result.log

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source-proxy.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source-proxy.sh
@@ -192,6 +192,12 @@ log "Login with sfdx CLI on the account #2"
 playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME_ACCOUNT2\" -p \"$SALESFORCE_PASSWORD_ACCOUNT2\" -r \"$SALESFORCE_INSTANCE_ACCOUNT2\" -s \"$SALESFORCE_SECURITY_TOKEN_ACCOUNT2\"" --shell sh
 
 log "Get the Lead created on account #2"
-playground container exec --container sfdx-cli --command "sfdx data:record:get --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -s Lead -w \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\"" --shell sh > /tmp/result.log  2>&1
+# data:query, not data:record:get: the sink inserts (it never upserts), so a shared org
+# accumulates Leads and an aborted run can leave one behind. data:record:get then fails
+# with "is not a unique qualifier for Lead; N records were retrieved" even though the
+# record the test just wrote is present. data:query returns every match, and the grep
+# below still fails if the record is genuinely missing.
+# || true so cat always runs - without it set -e aborts here and the error is never shown.
+playground container exec --container sfdx-cli --command "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" --shell sh > /tmp/result.log 2>&1 || true
 cat /tmp/result.log
 grep "$LEAD_FIRSTNAME" /tmp/result.log

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source.sh
@@ -179,6 +179,12 @@ log "Login with sfdx CLI on the account #2"
 playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME_ACCOUNT2\" -p \"$SALESFORCE_PASSWORD_ACCOUNT2\" -r \"$SALESFORCE_INSTANCE_ACCOUNT2\" -s \"$SALESFORCE_SECURITY_TOKEN_ACCOUNT2\"" --shell sh
 
 log "Get the Lead created on account #2"
-playground container exec --container sfdx-cli --command "sfdx data:record:get --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -s Lead -w \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\"" --shell sh > /tmp/result.log  2>&1
+# data:query, not data:record:get: the sink inserts (it never upserts), so a shared org
+# accumulates Leads and an aborted run can leave one behind. data:record:get then fails
+# with "is not a unique qualifier for Lead; N records were retrieved" even though the
+# record the test just wrote is present. data:query returns every match, and the grep
+# below still fails if the record is genuinely missing.
+# || true so cat always runs - without it set -e aborts here and the error is never shown.
+playground container exec --container sfdx-cli --command "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" --shell sh > /tmp/result.log 2>&1 || true
 cat /tmp/result.log
 grep "$LEAD_FIRSTNAME" /tmp/result.log

--- a/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source.sh
+++ b/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source.sh
@@ -56,11 +56,6 @@ cleanup_salesforce_test_data() {
   playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" --shell sh << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 EOF
-  # Release the session(s) this test opened. Each sfpowerkit:auth:login creates two
-  # Salesforce sessions, and without a logout they are left to expire - so a run
-  # accumulates sessions against the same user and later logins evict earlier ones
-  # ("Session expired or invalid").
-  playground container exec --container sfdx-cli --command "sfdx force:auth:logout --all --no-prompt" --shell sh > /dev/null
   set -e
 }
 trap cleanup_salesforce_test_data EXIT

--- a/connect/connect-salesforce-cdc-source/salesforce-cdc-source.sh
+++ b/connect/connect-salesforce-cdc-source/salesforce-cdc-source.sh
@@ -106,11 +106,6 @@ cleanup_salesforce_test_data() {
   playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" --shell sh << EOF
 Database.delete([SELECT Id FROM Contact WHERE FirstName = '$CONTACT_FIRSTNAME' AND LastName = '$CONTACT_LASTNAME'], false);
 EOF
-  # Release the session(s) this test opened. Each sfpowerkit:auth:login creates two
-  # Salesforce sessions, and without a logout they are left to expire - so a run
-  # accumulates sessions against the same user and later logins evict earlier ones
-  # ("Session expired or invalid").
-  playground container exec --container sfdx-cli --command "sfdx force:auth:logout --all --no-prompt" --shell sh > /dev/null
   set -e
 }
 trap cleanup_salesforce_test_data EXIT

--- a/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source.sh
+++ b/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source.sh
@@ -120,11 +120,6 @@ cleanup_salesforce_test_data() {
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
 EOF
-  # Release the session(s) this test opened. Each sfpowerkit:auth:login creates two
-  # Salesforce sessions, and without a logout they are left to expire - so a run
-  # accumulates sessions against the same user and later logins evict earlier ones
-  # ("Session expired or invalid").
-  playground container exec --container sfdx-cli --command "sfdx force:auth:logout --all --no-prompt" --shell sh > /dev/null
   set -e
 }
 trap cleanup_salesforce_test_data EXIT

--- a/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink-proxy.sh
+++ b/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink-proxy.sh
@@ -202,6 +202,12 @@ log "Login with sfdx CLI on the account #2"
 playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME_ACCOUNT2\" -p \"$SALESFORCE_PASSWORD_ACCOUNT2\" -r \"$SALESFORCE_INSTANCE_ACCOUNT2\" -s \"$SALESFORCE_SECURITY_TOKEN_ACCOUNT2\"" --shell sh
 
 log "Get the Lead created on account #2"
-playground container exec --container sfdx-cli --command "sfdx data:record:get --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -s Lead -w \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\"" --shell sh > /tmp/result.log  2>&1
+# data:query, not data:record:get: the sink inserts (it never upserts), so a shared org
+# accumulates Leads and an aborted run can leave one behind. data:record:get then fails
+# with "is not a unique qualifier for Lead; N records were retrieved" even though the
+# record the test just wrote is present. data:query returns every match, and the grep
+# below still fails if the record is genuinely missing.
+# || true so cat always runs - without it set -e aborts here and the error is never shown.
+playground container exec --container sfdx-cli --command "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" --shell sh > /tmp/result.log 2>&1 || true
 cat /tmp/result.log
 grep "$LEAD_FIRSTNAME" /tmp/result.log

--- a/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink.sh
+++ b/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink.sh
@@ -705,6 +705,12 @@ log "Login with sfdx CLI on the account #2"
 playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME_ACCOUNT2\" -p \"$SALESFORCE_PASSWORD_ACCOUNT2\" -r \"$SALESFORCE_INSTANCE_ACCOUNT2\" -s \"$SALESFORCE_SECURITY_TOKEN_ACCOUNT2\"" --shell sh
 
 log "Get the Lead created on account #2"
-playground container exec --container sfdx-cli --command "sfdx data:record:get --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -s Lead -w \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\"" --shell sh > /tmp/result.log  2>&1
+# data:query, not data:record:get: the sink inserts (it never upserts), so a shared org
+# accumulates Leads and an aborted run can leave one behind. data:record:get then fails
+# with "is not a unique qualifier for Lead; N records were retrieved" even though the
+# record the test just wrote is present. data:query returns every match, and the grep
+# below still fails if the record is genuinely missing.
+# || true so cat always runs - without it set -e aborts here and the error is never shown.
+playground container exec --container sfdx-cli --command "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" --shell sh > /tmp/result.log 2>&1 || true
 cat /tmp/result.log
 grep "$LEAD_FIRSTNAME" /tmp/result.log

--- a/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink.sh
+++ b/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink.sh
@@ -158,11 +158,6 @@ EOF
   playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" --shell sh << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 EOF
-  # Release the session(s) this test opened. Each sfpowerkit:auth:login creates two
-  # Salesforce sessions, and without a logout they are left to expire - so a run
-  # accumulates sessions against the same user and later logins evict earlier ones
-  # ("Session expired or invalid").
-  playground container exec --container sfdx-cli --command "sfdx force:auth:logout --all --no-prompt" --shell sh > /dev/null
   set -e
 }
 trap cleanup_salesforce_test_data EXIT


### PR DESCRIPTION
Two independent fixes to the Salesforce tests. Both verified against the shared test org.

---

## 1. The cross-org Lead lookup rejected duplicates

The sink tests that verify their record reached the second org intermittently failed at the
very end, with every assertion already green and **no error shown**:

```
✨ Display content of topic success-responses, it contains 1 messages
✨ Display content of topic error-responses, it contains 0 messages
   Login with sfdx CLI on the account #2
   Authorized to connect-system-tests+cdc@confluent.io
   Get the Lead created on account #2
🧹 Cleaning up: Lead John_24730 Doe_25713 (both orgs) …
🔥 RESULT: FAILURE
```

### Cause

```bash
sfdx data:record:get --target-org "$SALESFORCE_USERNAME_ACCOUNT2" -s Lead \
  -w "FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent"
```

`data:record:get` requires the where-clause to resolve to **exactly one** record:

```
Error (1): FirstName='…' LastName='…' Company=Confluent is not a unique qualifier
for Lead; 2 records were retrieved.
```

The sink connectors **insert** — never upsert — so a shared org accumulates Leads, and any
run that dies before its cleanup trap leaves one behind. `LEAD_FIRSTNAME` is `John_$RANDOM`
(0–32767), so a later run redrawing that pair fails **permanently**, even though the record
it just wrote is present and correct. The org used for these tests holds ~500
`Company='Confluent'` Leads, so orphans accumulate and each poisons its own name pair.

The error was invisible in CI because the command runs under `set -e`, so the following
`cat /tmp/result.log` never executed — the run showed only a bare `RESULT: FAILURE`.

### Fix

`data:query` returns every match and exits 0. The existing `grep` still fails when the
record is genuinely absent, so the assertion keeps its meaning — it just stops requiring a
uniqueness the tests never guaranteed. `|| true` is added so `cat` always runs.

### Verification

| Scenario | `data:record:get` | `data:query` |
|---|---|---|
| 2 matching Leads | exit 1, "not a unique qualifier" | exit 0, both rows, `grep` passes |
| 0 matching Leads | exit 1 | `retrieved: 0`, `grep` **fails** — regression still caught |

Full `salesforce-sobject-sink.sh` run with one duplicate pre-seeded in the second org:

- **before** — `RESULT: FAILURE`, `is not a unique qualifier for Lead; 2 records were retrieved`
- **after** — `RESULT: SUCCESS`, `/tmp/result.log` showing both rows

Applied to all six affected tests, including the proxy variants.

---

## 2. `sfdx force:auth:logout --all` in cleanup was a no-op that broke later steps

The cleanup traps ended with a logout, justified by a comment claiming a run "accumulates
sessions against the same user and later logins evict earlier ones". Both halves are wrong:

- **No per-user session cap exists.** The Developer Edition limit of 5 is *Concurrent API
  Request Limits* (requests running ≥20s) and returns `REQUEST_LIMIT_EXCEEDED` rather than
  evicting.
- **It makes no network call.** In the image these tests use (`sfdx-cli 7.209.6`,
  `plugin-auth 2.8.4`, `@salesforce/core 4.3.10`) it resolves to deleting
  `~/.sfdx/<user>.json`; there is no reference to `services/oauth2/revoke` in either
  package. Sessions lapsed on idle timeout either way.
- **It is redundant.** The sfdx-cli container is recreated per test — hence
  `Config folder does not exists, Creating Folder` on every login. The store already starts
  empty.

What it did do is delete credentials later steps need. Querying the second org after a test
consistently failed with `No authorization information found for <user>` until the account
was re-authenticated.

**Verified:** `salesforce-sobject-sink.sh` passes with the call removed, and a query against
the second org afterwards now succeeds with **no re-login** — previously it always failed.

---

`bash -n` clean on all changed files.