### PR TITLE
Salesforce: retry connector creation on transient errors from Salesforce

### DIFF
--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source-proxy.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source-proxy.sh
@@ -91,7 +91,7 @@ log "Blocking $DOMAIN IP $IP to make sure proxy is used"
 playground debug block-traffic --container connect --destination $IP --action start
 
 log "Creating Salesforce Bulk API Source connector"
-playground connector create-or-update --connector salesforce-bulkapi-source  << EOF
+salesforce_create_connector_with_retry salesforce-bulkapi-source << EOF
 {
     "connector.class": "io.confluent.connect.salesforce.SalesforceBulkApiSourceConnector",
     "kafka.topic": "sfdc-bulkapi-leads",
@@ -120,7 +120,7 @@ log "Verify we have received the data in sfdc-bulkapi-leads topic"
 playground topic consume --topic sfdc-bulkapi-leads --min-expected-messages 1 --timeout 60
 
 log "Creating Salesforce Bulk API Sink connector"
-playground connector create-or-update --connector salesforce-bulkapi-sink  << EOF
+salesforce_create_connector_with_retry salesforce-bulkapi-sink << EOF
 {
      "connector.class": "io.confluent.connect.salesforce.SalesforceBulkApiSinkConnector",
      "topics": "sfdc-bulkapi-leads",

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source.sh
@@ -163,7 +163,7 @@ restart_task_on_invalid_session() {
 }
 
 log "Creating Salesforce Bulk API Source connector"
-playground connector create-or-update --connector salesforce-bulkapi-source  << EOF
+salesforce_create_connector_with_retry salesforce-bulkapi-source << EOF
 {
      "connector.class": "io.confluent.connect.salesforce.SalesforceBulkApiSourceConnector",
      "kafka.topic": "sfdc-bulkapi-leads",
@@ -191,7 +191,7 @@ log "Verify we have received the data in sfdc-bulkapi-leads topic"
 playground topic consume --topic sfdc-bulkapi-leads --min-expected-messages 1 --timeout 180
 
 log "Creating Salesforce Bulk API Sink connector"
-playground connector create-or-update --connector salesforce-bulkapi-sink  << EOF
+salesforce_create_connector_with_retry salesforce-bulkapi-sink << EOF
 {
     "connector.class": "io.confluent.connect.salesforce.SalesforceBulkApiSinkConnector",
     "topics": "sfdc-bulkapi-leads",

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source-proxy.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source-proxy.sh
@@ -110,7 +110,7 @@ log "Blocking $DOMAIN IP $IP to make sure proxy is used"
 playground debug block-traffic --container connect --destination $IP --action start
 
 log "Creating Salesforce PushTopics Source connector"
-playground connector create-or-update --connector salesforce-pushtopic-source  << EOF
+salesforce_create_connector_with_retry salesforce-pushtopic-source << EOF
 {
      "connector.class": "io.confluent.salesforce.SalesforcePushTopicSourceConnector",
      "kafka.topic": "sfdc-pushtopic-leads",
@@ -150,7 +150,7 @@ playground topic consume --topic sfdc-pushtopic-leads --min-expected-messages 1 
 
 
 log "Creating Salesforce Bulk API Sink connector"
-playground connector create-or-update --connector salesforce-bulkapi-sink  << EOF
+salesforce_create_connector_with_retry salesforce-bulkapi-sink << EOF
 {
                     "connector.class": "io.confluent.connect.salesforce.SalesforceBulkApiSinkConnector",
                     "topics": "sfdc-pushtopic-leads",

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source.sh
@@ -100,7 +100,7 @@ log "Create $PUSH_TOPICS_NAME"
 playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/MyLeadPushTopics.apex\"" --shell sh
 
 log "Creating Salesforce PushTopics Source connector"
-playground connector create-or-update --connector salesforce-pushtopic-source  << EOF
+salesforce_create_connector_with_retry salesforce-pushtopic-source << EOF
 {
      "connector.class": "io.confluent.salesforce.SalesforcePushTopicSourceConnector",
      "kafka.topic": "sfdc-pushtopic-leads",
@@ -138,7 +138,7 @@ playground topic consume --topic sfdc-pushtopic-leads --min-expected-messages 1 
 
 
 log "Creating Salesforce Bulk API Sink connector"
-playground connector create-or-update --connector salesforce-bulkapi-sink  << EOF
+salesforce_create_connector_with_retry salesforce-bulkapi-sink << EOF
 {
                     "connector.class": "io.confluent.connect.salesforce.SalesforceBulkApiSinkConnector",
                     "topics": "sfdc-pushtopic-leads",

--- a/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source-proxy.sh
+++ b/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source-proxy.sh
@@ -52,7 +52,7 @@ log "Blocking $DOMAIN IP $IP to make sure proxy is used"
 playground debug block-traffic --container connect --destination $IP --action start
 
 log "Creating Salesforce Bulk API Source connector"
-playground connector create-or-update --connector salesforce-bulkapi-source  << EOF
+salesforce_create_connector_with_retry salesforce-bulkapi-source << EOF
 {
      "connector.class": "io.confluent.connect.salesforce.SalesforceBulkApiSourceConnector",
      "kafka.topic": "sfdc-bulkapi-leads",

--- a/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source.sh
+++ b/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source.sh
@@ -120,7 +120,7 @@ restart_task_on_invalid_session() {
 }
 
 log "Creating Salesforce Bulk API Source connector"
-playground connector create-or-update --connector salesforce-bulkapi-source  << EOF
+salesforce_create_connector_with_retry salesforce-bulkapi-source << EOF
 {
      "connector.class": "io.confluent.connect.salesforce.SalesforceBulkApiSourceConnector",
      "kafka.topic": "sfdc-bulkapi-leads",

--- a/connect/connect-salesforce-cdc-source/salesforce-cdc-source-proxy.sh
+++ b/connect/connect-salesforce-cdc-source/salesforce-cdc-source-proxy.sh
@@ -54,7 +54,7 @@ log "Blocking $DOMAIN IP $IP to make sure proxy is used"
 playground debug block-traffic --container connect --destination $IP --action start
 
 log "Creating Salesforce CDC Source connector"
-playground connector create-or-update --connector salesforce-cdc-source  << EOF
+salesforce_create_connector_with_retry salesforce-cdc-source << EOF
 {
      "connector.class": "io.confluent.salesforce.SalesforceCdcSourceConnector",
      "kafka.topic": "sfdc-cdc-contacts",

--- a/connect/connect-salesforce-cdc-source/salesforce-cdc-source.sh
+++ b/connect/connect-salesforce-cdc-source/salesforce-cdc-source.sh
@@ -55,7 +55,7 @@ PLAYGROUND_ENVIRONMENT=${PLAYGROUND_ENVIRONMENT:-"plaintext"}
 playground start-environment --environment "${PLAYGROUND_ENVIRONMENT}" --docker-compose-override-file "${PWD}/docker-compose.plaintext.yml"
 
 log "Creating Salesforce CDC Source connector"
-playground connector create-or-update --connector salesforce-cdc-source  << EOF
+salesforce_create_connector_with_retry salesforce-cdc-source << EOF
 {
      "connector.class": "io.confluent.salesforce.SalesforceCdcSourceConnector",
      "kafka.topic": "sfdc-cdc-contacts",

--- a/connect/connect-salesforce-platform-events-sink/salesforce-platform-events-sink-proxy-basic-auth.sh
+++ b/connect/connect-salesforce-platform-events-sink/salesforce-platform-events-sink-proxy-basic-auth.sh
@@ -57,7 +57,7 @@ playground debug block-traffic --container connect --destination $IP --action st
 
 
 log "Creating Salesforce Platform Events Source connector"
-playground connector create-or-update --connector salesforce-platform-events-source  << EOF
+salesforce_create_connector_with_retry salesforce-platform-events-source << EOF
 {
      "connector.class": "io.confluent.salesforce.SalesforcePlatformEventSourceConnector",
      "kafka.topic": "sfdc-platform-events",
@@ -97,7 +97,7 @@ log "Verify we have received the data in sfdc-platform-events topic"
 playground topic consume --topic sfdc-platform-events --min-expected-messages 2 --timeout 60
 
 log "Creating Salesforce Platform Events Sink connector"
-playground connector create-or-update --connector salesforce-platform-events-sink  << EOF
+salesforce_create_connector_with_retry salesforce-platform-events-sink << EOF
 {
      "connector.class": "io.confluent.salesforce.SalesforcePlatformEventSinkConnector",
      "topics": "sfdc-platform-events",

--- a/connect/connect-salesforce-platform-events-sink/salesforce-platform-events-sink-proxy.sh
+++ b/connect/connect-salesforce-platform-events-sink/salesforce-platform-events-sink-proxy.sh
@@ -56,7 +56,7 @@ log "Blocking $DOMAIN IP $IP to make sure proxy is used"
 playground debug block-traffic --container connect --destination $IP --action start
 
 log "Creating Salesforce Platform Events Source connector"
-playground connector create-or-update --connector salesforce-platform-events-source  << EOF
+salesforce_create_connector_with_retry salesforce-platform-events-source << EOF
 {
      "connector.class": "io.confluent.salesforce.SalesforcePlatformEventSourceConnector",
      "kafka.topic": "sfdc-platform-events",
@@ -93,7 +93,7 @@ log "Verify we have received the data in sfdc-platform-events topic"
 playground topic consume --topic sfdc-platform-events --min-expected-messages 2 --timeout 60
 
 log "Creating Salesforce Platform Events Sink connector"
-playground connector create-or-update --connector salesforce-platform-events-sink  << EOF
+salesforce_create_connector_with_retry salesforce-platform-events-sink << EOF
 {
      "connector.class": "io.confluent.salesforce.SalesforcePlatformEventSinkConnector",
      "topics": "sfdc-platform-events",

--- a/connect/connect-salesforce-platform-events-sink/salesforce-platform-events-sink.sh
+++ b/connect/connect-salesforce-platform-events-sink/salesforce-platform-events-sink.sh
@@ -51,7 +51,7 @@ PLAYGROUND_ENVIRONMENT=${PLAYGROUND_ENVIRONMENT:-"plaintext"}
 playground start-environment --environment "${PLAYGROUND_ENVIRONMENT}" --docker-compose-override-file "${PWD}/docker-compose.plaintext.yml"
 
 log "Creating Salesforce Platform Events Source connector"
-playground connector create-or-update --connector salesforce-platform-events-source  << EOF
+salesforce_create_connector_with_retry salesforce-platform-events-source << EOF
 {
      "connector.class": "io.confluent.salesforce.SalesforcePlatformEventSourceConnector",
      "kafka.topic": "sfdc-platform-events",
@@ -87,7 +87,7 @@ log "Verify we have received the data in sfdc-platform-events topic"
 playground topic consume --topic sfdc-platform-events --min-expected-messages 2 --timeout 60
 
 log "Creating Salesforce Platform Events Sink connector"
-playground connector create-or-update --connector salesforce-platform-events-sink  << EOF
+salesforce_create_connector_with_retry salesforce-platform-events-sink << EOF
 {
      "connector.class": "io.confluent.salesforce.SalesforcePlatformEventSinkConnector",
      "topics": "sfdc-platform-events",

--- a/connect/connect-salesforce-platform-events-source/salesforce-platform-events-source-proxy.sh
+++ b/connect/connect-salesforce-platform-events-source/salesforce-platform-events-source-proxy.sh
@@ -56,7 +56,7 @@ log "Blocking $DOMAIN IP $IP to make sure proxy is used"
 playground debug block-traffic --container connect --destination $IP --action start
 
 log "Creating Salesforce Platform Events Source connector"
-playground connector create-or-update --connector salesforce-platform-events-source  << EOF
+salesforce_create_connector_with_retry salesforce-platform-events-source << EOF
 {
      "connector.class": "io.confluent.salesforce.SalesforcePlatformEventSourceConnector",
      "kafka.topic": "sfdc-platform-events",

--- a/connect/connect-salesforce-platform-events-source/salesforce-platform-events-source.sh
+++ b/connect/connect-salesforce-platform-events-source/salesforce-platform-events-source.sh
@@ -49,7 +49,7 @@ PLAYGROUND_ENVIRONMENT=${PLAYGROUND_ENVIRONMENT:-"plaintext"}
 playground start-environment --environment "${PLAYGROUND_ENVIRONMENT}" --docker-compose-override-file "${PWD}/docker-compose.plaintext.yml"
 
 log "Creating Salesforce Platform Events Source connector"
-playground connector create-or-update --connector salesforce-platform-events-source  << EOF
+salesforce_create_connector_with_retry salesforce-platform-events-source << EOF
 {
      "connector.class": "io.confluent.salesforce.SalesforcePlatformEventSourceConnector",
      "kafka.topic": "sfdc-platform-events",

--- a/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy-basic-auth.sh
+++ b/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy-basic-auth.sh
@@ -90,7 +90,7 @@ curl --request PUT \
 }'
 
 log "Creating Salesforce PushTopics Source connector"
-playground connector create-or-update --connector salesforce-pushtopic-source-proxy-basic-auth  << EOF
+salesforce_create_connector_with_retry salesforce-pushtopic-source-proxy-basic-auth << EOF
 {
      "connector.class": "io.confluent.salesforce.SalesforcePushTopicSourceConnector",
      "kafka.topic": "sfdc-pushtopic-leads",

--- a/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy.sh
+++ b/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy.sh
@@ -78,7 +78,7 @@ log "Blocking $DOMAIN IP $IP to make sure proxy is used"
 playground debug block-traffic --container connect --destination $IP --action start
 
 log "Creating Salesforce PushTopics Source connector"
-playground connector create-or-update --connector salesforce-pushtopic-source  << EOF
+salesforce_create_connector_with_retry salesforce-pushtopic-source << EOF
 {
      "connector.class": "io.confluent.salesforce.SalesforcePushTopicSourceConnector",
      "kafka.topic": "sfdc-pushtopic-leads",

--- a/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source.sh
+++ b/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source.sh
@@ -77,7 +77,7 @@ log "Create $PUSH_TOPICS_NAME"
 playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/MyLeadPushTopics.apex\"" --shell sh
 
 log "Creating Salesforce PushTopics Source connector"
-playground connector create-or-update --connector salesforce-pushtopic-source  << EOF
+salesforce_create_connector_with_retry salesforce-pushtopic-source << EOF
 {
      "connector.class": "io.confluent.salesforce.SalesforcePushTopicSourceConnector",
      "kafka.topic": "sfdc-pushtopic-leads",

--- a/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink-proxy.sh
+++ b/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink-proxy.sh
@@ -118,7 +118,7 @@ log "Blocking $DOMAIN IP $IP to make sure proxy is used"
 playground debug block-traffic --container connect --destination $IP --action start
 
 log "Creating Salesforce PushTopics Source connector"
-playground connector create-or-update --connector salesforce-pushtopic-source  << EOF
+salesforce_create_connector_with_retry salesforce-pushtopic-source << EOF
 {
      "connector.class": "io.confluent.salesforce.SalesforcePushTopicSourceConnector",
      "kafka.topic": "sfdc-pushtopic-leads",
@@ -157,7 +157,7 @@ playground topic consume --topic sfdc-pushtopic-leads --min-expected-messages 1 
 
 
 log "Creating Salesforce SObject Sink connector"
-playground connector create-or-update --connector salesforce-sobject-sink  << EOF
+salesforce_create_connector_with_retry salesforce-sobject-sink << EOF
 {
     "connector.class": "io.confluent.salesforce.SalesforceSObjectSinkConnector",
     "topics": "sfdc-pushtopic-leads",

--- a/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink.sh
+++ b/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink.sh
@@ -110,7 +110,7 @@ log "Create $PUSH_TOPICS_NAME"
 playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/MyLeadPushTopics.apex\"" --shell sh
 
 log "Creating Salesforce PushTopics Source connector"
-playground connector create-or-update --connector salesforce-pushtopic-source  << EOF
+salesforce_create_connector_with_retry salesforce-pushtopic-source << EOF
 {
      "connector.class": "io.confluent.salesforce.SalesforcePushTopicSourceConnector",
      "kafka.topic": "sfdc-pushtopic-leads",
@@ -653,7 +653,7 @@ playground topic consume --topic sfdc-pushtopic-leads --min-expected-messages 1 
 # }
 
 log "Creating Salesforce SObject Sink connector"
-playground connector create-or-update --connector salesforce-sobject-sink  << EOF
+salesforce_create_connector_with_retry salesforce-sobject-sink << EOF
 {
     "connector.class": "io.confluent.salesforce.SalesforceSObjectSinkConnector",
     "topics": "sfdc-pushtopic-leads",

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -43,11 +43,16 @@ function cleanup-workaround-file {
 # Errors that mean "the external system briefly misbehaved", not "this config is wrong".
 # Kept deliberately narrow: anything not listed here fails on the first attempt, so a real
 # misconfiguration or a genuine connector bug is never retried into a green run.
+#
+# INVALID_SESSION_ID is included: Salesforce reuses one session across identical
+# username-password logins by the same user, so a concurrent logout elsewhere can
+# invalidate the session validation is holding. Retrying re-authenticates.
 SALESFORCE_TRANSIENT_CREATE_ERRORS="${SALESFORCE_TRANSIENT_CREATE_ERRORS:-\
 Exception encountered while calling salesforce|\
 Read timed out|Connection reset|Connection refused|\
 502 Bad Gateway|503 Service Unavailable|504 Gateway|\
-SERVER_UNAVAILABLE|Server Unavailable|UNABLE_TO_LOCK_ROW}"
+SERVER_UNAVAILABLE|Server Unavailable|UNABLE_TO_LOCK_ROW|\
+INVALID_SESSION_ID}"
 
 # Create a connector, retrying only when validation failed for a transient reason.
 #

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -54,6 +54,10 @@ Read timed out|Connection reset|Connection refused|\
 SERVER_UNAVAILABLE|Server Unavailable|UNABLE_TO_LOCK_ROW|\
 INVALID_SESSION_ID}"
 
+# Retries consumed so far by this test. Reset per test process, since each test runs in
+# its own shell - so the budget below is genuinely per test, not per connector.
+SALESFORCE_CREATE_RETRIES_USED=0
+
 # Create a connector, retrying only when validation failed for a transient reason.
 #
 # Connector validation calls out to Salesforce (token endpoint, /services/data/,
@@ -68,12 +72,24 @@ INVALID_SESSION_ID}"
 #   { ... }
 #   EOF
 #
+# The retry budget is per TEST, not per connector: SALESFORCE_CREATE_MAX_RETRIES retries
+# are shared across every connector a test creates, so a test that creates three
+# connectors cannot spend three retries on each of them. First attempts are never
+# counted against the budget.
+#
 # The body is read from stdin once and replayed on each attempt.
 function salesforce_create_connector_with_retry() {
   local connector="$1"
-  local max_attempts="${SALESFORCE_CREATE_MAX_ATTEMPTS:-3}"
+  local max_retries="${SALESFORCE_CREATE_MAX_RETRIES:-3}"
   local delay="${SALESFORCE_CREATE_RETRY_DELAY:-15}"
-  local body attempt=1 rc out
+  local body attempt=1 rc out had_errexit=0
+
+  # Remember whether the caller had errexit on, so it can be restored exactly. Setting
+  # it unconditionally would turn it on for callers that deliberately had it off - the
+  # cleanup traps run under set +e.
+  case $- in
+    *e*) had_errexit=1 ;;
+  esac
 
   body="$(cat)"
 
@@ -82,7 +98,10 @@ function salesforce_create_connector_with_retry() {
     set +e
     out="$(printf '%s\n' "$body" | playground connector create-or-update --connector "$connector" 2>&1)"
     rc=$?
-    set -e
+    if [ $had_errexit -eq 1 ]
+    then
+      set -e
+    fi
     echo "$out"
 
     if [ $rc -eq 0 ]
@@ -100,13 +119,14 @@ function salesforce_create_connector_with_retry() {
       return $rc
     fi
 
-    if [ $attempt -ge $max_attempts ]
+    if [ "$SALESFORCE_CREATE_RETRIES_USED" -ge "$max_retries" ]
     then
-      logerror "❌ $connector still failing with a transient error after $attempt attempt(s)"
+      logerror "❌ $connector hit a transient error but this test has already used its $max_retries retry(ies)"
       return $rc
     fi
 
-    logwarn "⚠️ transient error creating $connector (attempt $attempt/$max_attempts), retrying in ${delay}s"
+    SALESFORCE_CREATE_RETRIES_USED=$((SALESFORCE_CREATE_RETRIES_USED + 1))
+    logwarn "⚠️ transient error creating $connector, retrying in ${delay}s (retry $SALESFORCE_CREATE_RETRIES_USED/$max_retries for this test)"
     sleep "$delay"
     attempt=$((attempt + 1))
   done

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -40,6 +40,73 @@ function cleanup-workaround-file {
   rm -f /tmp/without-cli-workaround > /dev/null 2>&1
 }
 
+# Errors that mean "the external system briefly misbehaved", not "this config is wrong".
+# Kept deliberately narrow: anything not listed here fails on the first attempt, so a real
+# misconfiguration or a genuine connector bug is never retried into a green run.
+SALESFORCE_TRANSIENT_CREATE_ERRORS="${SALESFORCE_TRANSIENT_CREATE_ERRORS:-\
+Exception encountered while calling salesforce|\
+Read timed out|Connection reset|Connection refused|\
+502 Bad Gateway|503 Service Unavailable|504 Gateway|\
+SERVER_UNAVAILABLE|Server Unavailable|UNABLE_TO_LOCK_ROW}"
+
+# Create a connector, retrying only when validation failed for a transient reason.
+#
+# Connector validation calls out to Salesforce (token endpoint, /services/data/,
+# describeSObject). A single blip there aborts the whole test even though nothing is
+# wrong with the connector or the test. Observed in CI: validation got HTTP 404 from
+# /services/data/ one second after a successful JWT auth, twice, then the identical
+# commit passed - so the failure is intermittent and upstream.
+#
+# Usage is identical to `playground connector create-or-update --connector X << EOF`:
+#
+#   salesforce_create_connector_with_retry salesforce-cdc-source << EOF
+#   { ... }
+#   EOF
+#
+# The body is read from stdin once and replayed on each attempt.
+function salesforce_create_connector_with_retry() {
+  local connector="$1"
+  local max_attempts="${SALESFORCE_CREATE_MAX_ATTEMPTS:-3}"
+  local delay="${SALESFORCE_CREATE_RETRY_DELAY:-15}"
+  local body attempt=1 rc out
+
+  body="$(cat)"
+
+  while true
+  do
+    set +e
+    out="$(printf '%s\n' "$body" | playground connector create-or-update --connector "$connector" 2>&1)"
+    rc=$?
+    set -e
+    echo "$out"
+
+    if [ $rc -eq 0 ]
+    then
+      if [ $attempt -gt 1 ]
+      then
+        log "✅ $connector created on attempt $attempt"
+      fi
+      return 0
+    fi
+
+    if ! echo "$out" | grep -qE "$SALESFORCE_TRANSIENT_CREATE_ERRORS"
+    then
+      logerror "❌ $connector creation failed for a non-transient reason, not retrying"
+      return $rc
+    fi
+
+    if [ $attempt -ge $max_attempts ]
+    then
+      logerror "❌ $connector still failing with a transient error after $attempt attempt(s)"
+      return $rc
+    fi
+
+    logwarn "⚠️ transient error creating $connector (attempt $attempt/$max_attempts), retrying in ${delay}s"
+    sleep "$delay"
+    attempt=$((attempt + 1))
+  done
+}
+
 function salesforce_ensure_jwt_keystore() {
   local target_dir="${1:-$PWD}"
   local keystore_path="$target_dir/salesforce-confluent.keystore.jks"


### PR DESCRIPTION
## Problem

Connector validation calls out to Salesforce — the OAuth token endpoint, /services/data/
for API version discovery, then describeSObject. A single blip on any of those aborts the
whole test even though nothing is wrong with the connector or the test.

Seen in CI twice in a row on salesforce-cdc-source.sh:

```
Creating Salesforce CDC Source connector
🔥 Command failed with error code 500
🔥 Connector validation failed: Exception encountered while calling salesforce
🔥 RESULT: FAILURE (took: 0min 46sec)
```

The connect container log shows authentication succeeding, and the 404 landing one second
later on version discovery:

```
INFO Using Salesforce instance from authentication:
     https://confluent-6e-dev-ed.my.salesforce.com
ConnectException: Exception encountered while calling salesforce
    at SalesforceRestClientImpl.apiVersions(SalesforceRestClientImpl.java:314)
    at AbstractSalesforceValidation.createAndValidateClient(...:187)
Caused by: HttpResponseException: 404 Not Found
```

The instance URL is correct, /services/data/ is an unauthenticated endpoint that returns
200 on request, and the identical commit passed on the next CI run. The same test also
passes locally — 8 runs, 8 passes, including with CI's exact connector build, CP version,
connect image and credentials. So the failure is intermittent and upstream.

Worth noting the 404 body was not Salesforce JSON, which is why no API error detail was
appended to the message; a genuine Salesforce API error returns a JSON array with a message.

## Change

`salesforce_create_connector_with_retry` in `scripts/utils.sh`, next to the existing
`salesforce_ensure_jwt_keystore`. It reads the connector body from stdin once and replays it
per attempt, so call sites keep their heredocs and only the command name changes:

```bash
salesforce_create_connector_with_retry salesforce-cdc-source << EOF
{ ... }
EOF
```

The allowlist is deliberately narrow, and anything not on it fails on the **first** attempt,
so a bad config or a genuine connector bug is never retried into a green run:

```
Exception encountered while calling salesforce
Read timed out | Connection reset | Connection refused
502 Bad Gateway | 503 Service Unavailable | 504 Gateway
SERVER_UNAVAILABLE | Server Unavailable | UNABLE_TO_LOCK_ROW
INVALID_SESSION_ID
```

Every retry logs a warning, so a flaky run stays visibly flaky rather than silently green.

`INVALID_SESSION_ID` is included. Salesforce reuses one session across identical
username-password logins by the same user, so a logout elsewhere — the Bulk API connector's
own validation calls one, and so does each task's `stop()` — can invalidate the session that
validation is holding. Retrying re-authenticates. The 3-attempt limit means a persistent
session problem still fails the test rather than looping.

### The retry budget is per test, not per connector

`SALESFORCE_CREATE_MAX_RETRIES` (default 3) is shared across every connector a single test
creates, so a test creating three connectors cannot spend three retries on each. First
attempts are never counted against it. Each test runs in its own shell, so the counter is
naturally per test.

Verified with a fake `playground` that always returns a transient error — one test creating
three connectors makes **6** invocations (3 uncounted first attempts + 3 shared retries),
where a per-connector cap would have made 12. The first connector consumes the budget and
the other two then fail on their first attempt.

Tunable via `SALESFORCE_TRANSIENT_CREATE_ERRORS`, `SALESFORCE_CREATE_MAX_RETRIES`
(default 3) and `SALESFORCE_CREATE_RETRY_DELAY` (default 15).

### errexit is preserved

An earlier revision did `set +e ... set -e` unconditionally, which turned errexit **on** for
callers that had deliberately turned it off — the cleanup traps run under `set +e`. The
helper now records the caller's state and restores exactly that, verified in both
directions.

## Verification

Against a fake `playground` command, checking attempt counts:

| Scenario | Expected | Result |
|---|---|---|
| succeeds first time | rc=0, 1 attempt | pass |
| 2 transient then success | rc=0, 3 attempts, warnings logged | pass |
| transient forever | rc=1, 3 attempts then gives up | pass |
| invalid config | rc=1, 1 attempt, NOT retried | pass |

And end to end against the shared test org — salesforce-cdc-source.sh creates the connector,
receives its CDC event and passes in 1m12s, unchanged from the 1m06s baseline. That confirms
the heredoc body survives the read-and-replay and there is no overhead on the happy path.

27 call sites across 18 tests; `bash -n` clean on all of them.

## Scope

Connector creation only. That covers validation, which is where this class of failure lands.
Transient failures elsewhere in a test (topic assertions, cleanup) are not covered — better
added case by case with evidence than blanket-retried now.


## Blast radius

Deliberately confined to the Salesforce tests:

- 19 files changed: 18 Salesforce tests plus `scripts/utils.sh`
- The `scripts/utils.sh` change is **purely additive** — 64 lines added, **0 removed**
- Only Salesforce tests call the new helper; the 380 other tests that use
  `playground connector create-or-update` are **untouched**
- No name collisions: the function name and all three env vars
  (`SALESFORCE_TRANSIENT_CREATE_ERRORS`, `SALESFORCE_CREATE_MAX_ATTEMPTS`,
  `SALESFORCE_CREATE_RETRY_DELAY`) appear nowhere else in the repo
- Sourcing `scripts/utils.sh` still returns 0 for a non-Salesforce test
