### PR TITLE
Salesforce: pick the Bulk API grant from the connector version under test

### DIFF
--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source-proxy.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source-proxy.sh
@@ -73,12 +73,12 @@ PLAYGROUND_ENVIRONMENT=${PLAYGROUND_ENVIRONMENT:-"plaintext"}
 playground start-environment --environment "${PLAYGROUND_ENVIRONMENT}" --docker-compose-override-file "${PWD}/docker-compose.plaintext.proxy.yml"
 
 log "Login with sfdx CLI"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\""
 
 LEAD_FIRSTNAME=John_$RANDOM
 LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
-playground container exec --container sfdx-cli --command "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\"" --shell sh
+salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
 DOMAIN=$(echo $SALESFORCE_INSTANCE | cut -d "/" -f 3)
 IP=$(nslookup $DOMAIN | grep Address | grep -v "#" | cut -d " " -f 2 | tail -1)
@@ -159,11 +159,11 @@ sleep 30
 log "Verify topic success-responses"
 playground topic consume --topic success-responses --min-expected-messages 1 --timeout 60
 
-# log "Verify topic error-responses"
-playground topic consume --topic error-responses --min-expected-messages 0 --timeout 60
+log "Verify the connector reported no errors"
+salesforce_assert_topic_empty error-responses
 
 log "Login with sfdx CLI on the account #2"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME_ACCOUNT2\" -p \"$SALESFORCE_PASSWORD_ACCOUNT2\" -r \"$SALESFORCE_INSTANCE_ACCOUNT2\" -s \"$SALESFORCE_SECURITY_TOKEN_ACCOUNT2\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME_ACCOUNT2\" -p \"$SALESFORCE_PASSWORD_ACCOUNT2\" -r \"$SALESFORCE_INSTANCE_ACCOUNT2\" -s \"$SALESFORCE_SECURITY_TOKEN_ACCOUNT2\""
 
 log "Get the Lead created on account #2"
 # data:query, not data:record:get: the sink inserts (it never upserts), so a shared org
@@ -172,6 +172,6 @@ log "Get the Lead created on account #2"
 # record the test just wrote is present. data:query returns every match, and the grep
 # below still fails if the record is genuinely missing.
 # || true so cat always runs - without it set -e aborts here and the error is never shown.
-playground container exec --container sfdx-cli --command "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" --shell sh > /tmp/result.log 2>&1 || true
+salesforce_sfdx_with_retry "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" > /tmp/result.log 2>&1 || true
 cat /tmp/result.log
 grep "$LEAD_FIRSTNAME" /tmp/result.log

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source.sh
@@ -11,6 +11,7 @@ then
      exit 111
 fi
 
+SALESFORCE_CONSUMER_KEY_WITH_JWT=${SALESFORCE_CONSUMER_KEY_WITH_JWT:-$3}
 SALESFORCE_USERNAME=${SALESFORCE_USERNAME:-$1}
 SALESFORCE_PASSWORD=${SALESFORCE_PASSWORD:-$2}
 SALESFORCE_SECURITY_TOKEN=${SALESFORCE_SECURITY_TOKEN:-$4}
@@ -21,6 +22,7 @@ SALESFORCE_INSTANCE=${SALESFORCE_INSTANCE:-"https://login.salesforce.com"}
 SALESFORCE_USERNAME_ACCOUNT2=${SALESFORCE_USERNAME_ACCOUNT2:-$5}
 SALESFORCE_PASSWORD_ACCOUNT2=${SALESFORCE_PASSWORD_ACCOUNT2:-$6}
 SALESFORCE_SECURITY_TOKEN_ACCOUNT2=${SALESFORCE_SECURITY_TOKEN_ACCOUNT2:-$7}
+SALESFORCE_CONSUMER_KEY_WITH_JWT_ACCOUNT2=${SALESFORCE_CONSUMER_KEY_WITH_JWT_ACCOUNT2:-$8}
 SALESFORCE_INSTANCE_ACCOUNT2=${SALESFORCE_INSTANCE_ACCOUNT2:-"https://login.salesforce.com"}
 
 if [ -z "$SALESFORCE_USERNAME" ]
@@ -70,6 +72,53 @@ fi
 
 sed -e "s|:PUSH_TOPIC_NAME:|$PUSH_TOPICS_NAME|g" \
      ../../connect/connect-salesforce-bulkapi-sink/MyLeadPushTopics-template.apex > ../../connect/connect-salesforce-bulkapi-sink/MyLeadPushTopics.apex
+
+
+# JWT_BEARER for the Bulk API connector arrived in 3.0.x; older artifacts only support the
+# username-password SOAP grant. Rather than duplicating this test per grant, or skipping it
+# on older artifacts, pick the grant from the version actually under test. An undeterminable
+# version falls back to username-password, which every version supports.
+SALESFORCE_CONNECTOR_VERSION="$(salesforce_connector_version)"
+if [ -n "$SALESFORCE_CONNECTOR_VERSION" ] && ! version_gt "3.0.0" "$SALESFORCE_CONNECTOR_VERSION"
+then
+  SALESFORCE_GRANT=JWT_BEARER
+else
+  SALESFORCE_GRANT=PASSWORD
+fi
+log "🔐 connector ${SALESFORCE_CONNECTOR_VERSION:-unknown} -> authenticating with $SALESFORCE_GRANT"
+
+if [ "$SALESFORCE_GRANT" = "JWT_BEARER" ]
+then
+  for v in SALESFORCE_CONSUMER_KEY_WITH_JWT SALESFORCE_CONSUMER_KEY_WITH_JWT_ACCOUNT2
+  do
+    if [ -z "${!v}" ]
+    then
+         logerror "$v is not set. Export it as environment variable or pass it as argument. Check README !"
+         exit 1
+    fi
+  done
+  # Both orgs' connected apps trust the same certificate, so one keystore covers source and
+  # sink. docker-compose.plaintext.yml already mounts it into connect at /tmp.
+  salesforce_ensure_jwt_keystore "$PWD" > /dev/null
+
+  SALESFORCE_SOURCE_AUTH="\"salesforce.grant.type\" : \"JWT_BEARER\",
+     \"salesforce.username\" : \"$SALESFORCE_USERNAME\",
+     \"salesforce.consumer.key\" : \"$SALESFORCE_CONSUMER_KEY_WITH_JWT\",
+     \"salesforce.jwt.keystore.path\" : \"/tmp/salesforce-confluent.keystore.jks\",
+     \"salesforce.jwt.keystore.password\" : \"confluent\","
+  SALESFORCE_SINK_AUTH="\"salesforce.grant.type\" : \"JWT_BEARER\",
+     \"salesforce.username\" : \"$SALESFORCE_USERNAME_ACCOUNT2\",
+     \"salesforce.consumer.key\" : \"$SALESFORCE_CONSUMER_KEY_WITH_JWT_ACCOUNT2\",
+     \"salesforce.jwt.keystore.path\" : \"/tmp/salesforce-confluent.keystore.jks\",
+     \"salesforce.jwt.keystore.password\" : \"confluent\","
+else
+  SALESFORCE_SOURCE_AUTH="\"salesforce.username\" : \"$SALESFORCE_USERNAME\",
+     \"salesforce.password\" : \"$SALESFORCE_PASSWORD\",
+     \"salesforce.password.token\" : \"$SALESFORCE_SECURITY_TOKEN\","
+  SALESFORCE_SINK_AUTH="\"salesforce.username\" : \"$SALESFORCE_USERNAME_ACCOUNT2\",
+     \"salesforce.password\" : \"$SALESFORCE_PASSWORD_ACCOUNT2\",
+     \"salesforce.password.token\" : \"$SALESFORCE_SECURITY_TOKEN_ACCOUNT2\","
+fi
 
 PLAYGROUND_ENVIRONMENT=${PLAYGROUND_ENVIRONMENT:-"plaintext"}
 playground start-environment --environment "${PLAYGROUND_ENVIRONMENT}" --docker-compose-override-file "${PWD}/docker-compose.plaintext.yml"
@@ -173,9 +222,7 @@ salesforce_create_connector_with_retry salesforce-bulkapi-source << EOF
      "curl.logging": "true",
      "salesforce.object" : "Lead",
      "salesforce.instance" : "$SALESFORCE_INSTANCE",
-     "salesforce.username" : "$SALESFORCE_USERNAME",
-     "salesforce.password" : "$SALESFORCE_PASSWORD",
-     "salesforce.password.token" : "$SALESFORCE_SECURITY_TOKEN",
+     $SALESFORCE_SOURCE_AUTH
      "connection.max.message.size": "10048576",
      "key.converter": "org.apache.kafka.connect.json.JsonConverter",
      "value.converter": "org.apache.kafka.connect.json.JsonConverter",
@@ -185,7 +232,7 @@ salesforce_create_connector_with_retry salesforce-bulkapi-source << EOF
 }
 EOF
 
-restart_task_on_invalid_session salesforce-bulkapi-source
+if [ "$SALESFORCE_GRANT" = "PASSWORD" ]; then restart_task_on_invalid_session salesforce-bulkapi-source; fi
 
 # 180s, not 60s: the Bulk API query job runs asynchronously on a Salesforce-side
 # queue, so its completion time is not under this test's control.
@@ -201,9 +248,7 @@ salesforce_create_connector_with_retry salesforce-bulkapi-sink << EOF
     "curl.logging": "true",
     "salesforce.object" : "Lead",
     "salesforce.instance" : "$SALESFORCE_INSTANCE_ACCOUNT2",
-    "salesforce.username" : "$SALESFORCE_USERNAME_ACCOUNT2",
-     "salesforce.password" : "$SALESFORCE_PASSWORD_ACCOUNT2",
-     "salesforce.password.token" : "$SALESFORCE_SECURITY_TOKEN_ACCOUNT2",
+    $SALESFORCE_SINK_AUTH
     "salesforce.ignore.fields" : "CleanStatus",
     "salesforce.ignore.reference.fields" : "true",
     "connection.max.message.size": "10048576",
@@ -224,7 +269,7 @@ salesforce_create_connector_with_retry salesforce-bulkapi-sink << EOF
 }
 EOF
 
-restart_task_on_invalid_session salesforce-bulkapi-sink
+if [ "$SALESFORCE_GRANT" = "PASSWORD" ]; then restart_task_on_invalid_session salesforce-bulkapi-sink; fi
 
 sleep 30
 

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source.sh
@@ -75,12 +75,12 @@ PLAYGROUND_ENVIRONMENT=${PLAYGROUND_ENVIRONMENT:-"plaintext"}
 playground start-environment --environment "${PLAYGROUND_ENVIRONMENT}" --docker-compose-override-file "${PWD}/docker-compose.plaintext.yml"
 
 log "Login with sfdx CLI"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\""
 
 LEAD_FIRSTNAME=John_$RANDOM
 LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
-playground container exec --container sfdx-cli --command "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\"" --shell sh
+salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
 # Remove what this test created, so repeated runs do not accumulate records in
 # shared Salesforce orgs. This test writes to two orgs: the Lead seeded above in
@@ -92,11 +92,11 @@ playground container exec --container sfdx-cli --command "sfdx data:create:recor
 cleanup_salesforce_test_data() {
   set +e
   log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME (both orgs) and PushTopic $PUSH_TOPICS_NAME"
-  playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" --shell sh << EOF
+  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
 EOF
-  playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" --shell sh << EOF
+  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 EOF
   set -e
@@ -234,11 +234,11 @@ sleep 30
 log "Verify topic success-responses"
 playground topic consume --topic success-responses --min-expected-messages 1 --timeout 180
 
-# log "Verify topic error-responses"
-playground topic consume --topic error-responses --min-expected-messages 0 --timeout 60
+log "Verify the connector reported no errors"
+salesforce_assert_topic_empty error-responses
 
 log "Login with sfdx CLI on the account #2"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME_ACCOUNT2\" -p \"$SALESFORCE_PASSWORD_ACCOUNT2\" -r \"$SALESFORCE_INSTANCE_ACCOUNT2\" -s \"$SALESFORCE_SECURITY_TOKEN_ACCOUNT2\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME_ACCOUNT2\" -p \"$SALESFORCE_PASSWORD_ACCOUNT2\" -r \"$SALESFORCE_INSTANCE_ACCOUNT2\" -s \"$SALESFORCE_SECURITY_TOKEN_ACCOUNT2\""
 
 log "Get the Lead created on account #2"
 # data:query, not data:record:get: the sink inserts (it never upserts), so a shared org
@@ -247,6 +247,6 @@ log "Get the Lead created on account #2"
 # record the test just wrote is present. data:query returns every match, and the grep
 # below still fails if the record is genuinely missing.
 # || true so cat always runs - without it set -e aborts here and the error is never shown.
-playground container exec --container sfdx-cli --command "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" --shell sh > /tmp/result.log 2>&1 || true
+salesforce_sfdx_with_retry "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" > /tmp/result.log 2>&1 || true
 cat /tmp/result.log
 grep "$LEAD_FIRSTNAME" /tmp/result.log

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source.sh
@@ -91,6 +91,8 @@ salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_
 # because that org is not authenticated until later in the script.
 cleanup_salesforce_test_data() {
   set +e
+  salesforce_sfdx_relogin ""
+  salesforce_sfdx_relogin "_ACCOUNT2"
   log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME (both orgs) and PushTopic $PUSH_TOPICS_NAME"
   salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source-proxy.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source-proxy.sh
@@ -87,17 +87,17 @@ playground start-environment --environment "${PLAYGROUND_ENVIRONMENT}" --docker-
 # the Salesforce PushTopic source connector is used to get data into Kafka and the Salesforce Bulk API sink connector is used to export data from Kafka to Salesforce
 
 log "Login with sfdx CLI"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\""
 
 log "Delete $PUSH_TOPICS_NAME, if required"
 set +e
-playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" --shell sh << EOF
+salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 List<PushTopic> pts = [SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'];
 Database.delete(pts);
 EOF
 set -e
 log "Create $PUSH_TOPICS_NAME"
-playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/MyLeadPushTopics.apex\"" --shell sh
+salesforce_sfdx_with_retry "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/MyLeadPushTopics.apex\""
 
 DOMAIN=$(echo $SALESFORCE_INSTANCE | cut -d "/" -f 3)
 IP=$(nslookup $DOMAIN | grep Address | grep -v "#" | cut -d " " -f 2 | tail -1)
@@ -140,7 +140,7 @@ sleep 5
 LEAD_FIRSTNAME=John_$RANDOM
 LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
-playground container exec --container sfdx-cli --command "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\"" --shell sh
+salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
 
 sleep 30
@@ -185,11 +185,11 @@ sleep 10
 log "Verify topic success-responses"
 playground topic consume --topic success-responses --min-expected-messages 1 --timeout 60
 
-# log "Verify topic error-responses"
-playground topic consume --topic error-responses --min-expected-messages 0 --timeout 60
+log "Verify the connector reported no errors"
+salesforce_assert_topic_empty error-responses
 
 log "Login with sfdx CLI on the account #2"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME_ACCOUNT2\" -p \"$SALESFORCE_PASSWORD_ACCOUNT2\" -r \"$SALESFORCE_INSTANCE_ACCOUNT2\" -s \"$SALESFORCE_SECURITY_TOKEN_ACCOUNT2\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME_ACCOUNT2\" -p \"$SALESFORCE_PASSWORD_ACCOUNT2\" -r \"$SALESFORCE_INSTANCE_ACCOUNT2\" -s \"$SALESFORCE_SECURITY_TOKEN_ACCOUNT2\""
 
 log "Get the Lead created on account #2"
 # data:query, not data:record:get: the sink inserts (it never upserts), so a shared org
@@ -198,6 +198,6 @@ log "Get the Lead created on account #2"
 # record the test just wrote is present. data:query returns every match, and the grep
 # below still fails if the record is genuinely missing.
 # || true so cat always runs - without it set -e aborts here and the error is never shown.
-playground container exec --container sfdx-cli --command "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" --shell sh > /tmp/result.log 2>&1 || true
+salesforce_sfdx_with_retry "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" > /tmp/result.log 2>&1 || true
 cat /tmp/result.log
 grep "$LEAD_FIRSTNAME" /tmp/result.log

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source.sh
@@ -87,17 +87,17 @@ playground start-environment --environment "${PLAYGROUND_ENVIRONMENT}" --docker-
 # the Salesforce PushTopic source connector is used to get data into Kafka and the Salesforce Bulk API sink connector is used to export data from Kafka to Salesforce
 
 log "Login with sfdx CLI"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\""
 
 log "Delete $PUSH_TOPICS_NAME, if required"
 set +e
-playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" --shell sh << EOF
+salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 List<PushTopic> pts = [SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'];
 Database.delete(pts);
 EOF
 set -e
 log "Create $PUSH_TOPICS_NAME"
-playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/MyLeadPushTopics.apex\"" --shell sh
+salesforce_sfdx_with_retry "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/MyLeadPushTopics.apex\""
 
 log "Creating Salesforce PushTopics Source connector"
 salesforce_create_connector_with_retry salesforce-pushtopic-source << EOF
@@ -129,7 +129,7 @@ sleep 5
 LEAD_FIRSTNAME=John_$RANDOM
 LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
-playground container exec --container sfdx-cli --command "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\"" --shell sh
+salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
 sleep 30
 
@@ -172,11 +172,11 @@ sleep 10
 log "Verify topic success-responses"
 playground topic consume --topic success-responses --min-expected-messages 1 --timeout 60
 
-# log "Verify topic error-responses"
-playground topic consume --topic error-responses --min-expected-messages 0 --timeout 60
+log "Verify the connector reported no errors"
+salesforce_assert_topic_empty error-responses
 
 log "Login with sfdx CLI on the account #2"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME_ACCOUNT2\" -p \"$SALESFORCE_PASSWORD_ACCOUNT2\" -r \"$SALESFORCE_INSTANCE_ACCOUNT2\" -s \"$SALESFORCE_SECURITY_TOKEN_ACCOUNT2\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME_ACCOUNT2\" -p \"$SALESFORCE_PASSWORD_ACCOUNT2\" -r \"$SALESFORCE_INSTANCE_ACCOUNT2\" -s \"$SALESFORCE_SECURITY_TOKEN_ACCOUNT2\""
 
 log "Get the Lead created on account #2"
 # data:query, not data:record:get: the sink inserts (it never upserts), so a shared org
@@ -185,6 +185,6 @@ log "Get the Lead created on account #2"
 # record the test just wrote is present. data:query returns every match, and the grep
 # below still fails if the record is genuinely missing.
 # || true so cat always runs - without it set -e aborts here and the error is never shown.
-playground container exec --container sfdx-cli --command "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" --shell sh > /tmp/result.log 2>&1 || true
+salesforce_sfdx_with_retry "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" > /tmp/result.log 2>&1 || true
 cat /tmp/result.log
 grep "$LEAD_FIRSTNAME" /tmp/result.log

--- a/connect/connect-salesforce-bulkapi-sink/stop.sh
+++ b/connect/connect-salesforce-bulkapi-sink/stop.sh
@@ -5,24 +5,18 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/../../scripts/utils.sh
 
-if [ ! -z "$GITHUB_RUN_NUMBER" ]
-then
-     # running with github actions
-
-
-    # second account (for Bulk API sink)
-    SALESFORCE_USERNAME_ACCOUNT2=${SALESFORCE_USERNAME_ACCOUNT2:-$6}
-    SALESFORCE_PASSWORD_ACCOUNT2=${SALESFORCE_PASSWORD_ACCOUNT2:-$7}
-    SALESFORCE_SECURITY_TOKEN_ACCOUNT2=${SALESFORCE_SECURITY_TOKEN_ACCOUNT2:-$8}
-    SALESFORCE_INSTANCE_ACCOUNT2=${SALESFORCE_INSTANCE_ACCOUNT2:-"https://login.salesforce.com"}
-
-    log "Login with sfdx CLI on the account #2"
-    playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME_ACCOUNT2\" -p \"$SALESFORCE_PASSWORD_ACCOUNT2\" -r \"$SALESFORCE_INSTANCE_ACCOUNT2\" -s \"$SALESFORCE_SECURITY_TOKEN_ACCOUNT2\"" --shell sh
-
-    log "Bulk delete leads"
-    playground container exec --container sfdx-cli --command "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id FROM Lead\" --result-format csv" --shell sh > /tmp/out.csv
-    playground container cp --source /tmp/out.csv --destination sfdx-cli:/tmp/out.csv
-    playground container exec --container sfdx-cli --command "sfdx force:data:bulk:delete --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -s Lead -f /tmp/out.csv" --shell sh
-fi
+# The teardown used to run:
+#   sfdx data:query -q "SELECT Id FROM Lead" --result-format csv > /tmp/out.csv
+#   sfdx force:data:bulk:delete -s Lead -f /tmp/out.csv
+# It has never worked. The redirect captures the CLI's own progress output
+# ("Querying Data... done", "Total number of records retrieved: N") into the CSV, so every
+# run ended in "InvalidBatch : Records not found" - observed on all four invocations of a
+# recent CI run. That is also why a shared org accumulated hundreds of stale Leads despite
+# an apparent "delete all Leads" teardown.
+#
+# It is removed rather than repaired: the query was unfiltered, so a working version would
+# delete EVERY Lead in the org including hand-made sample data. Each test already removes
+# exactly the records it created, in its own EXIT trap. A filtered sweep for leftovers from
+# aborted runs can be added separately, matching only the test naming patterns.
 
 stop_all "$DIR"

--- a/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source-proxy.sh
+++ b/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source-proxy.sh
@@ -39,12 +39,12 @@ PLAYGROUND_ENVIRONMENT=${PLAYGROUND_ENVIRONMENT:-"plaintext"}
 playground start-environment --environment "${PLAYGROUND_ENVIRONMENT}" --docker-compose-override-file "${PWD}/docker-compose.plaintext.proxy.yml"
 
 log "Login with sfdx CLI"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\""
 
 LEAD_FIRSTNAME=John_$RANDOM
 LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
-playground container exec --container sfdx-cli --command "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\"" --shell sh
+salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
 DOMAIN=$(echo $SALESFORCE_INSTANCE | cut -d "/" -f 3)
 IP=$(nslookup $DOMAIN | grep Address | grep -v "#" | cut -d " " -f 2 | tail -1)

--- a/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source.sh
+++ b/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source.sh
@@ -52,6 +52,7 @@ salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_
 # also happens when an assertion below fails.
 cleanup_salesforce_test_data() {
   set +e
+  salesforce_sfdx_relogin ""
   log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME"
   salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);

--- a/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source.sh
+++ b/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source.sh
@@ -11,6 +11,7 @@ then
      exit 111
 fi
 
+SALESFORCE_CONSUMER_KEY_WITH_JWT=${SALESFORCE_CONSUMER_KEY_WITH_JWT:-$3}
 SALESFORCE_USERNAME=${SALESFORCE_USERNAME:-$1}
 SALESFORCE_PASSWORD=${SALESFORCE_PASSWORD:-$2}
 SALESFORCE_SECURITY_TOKEN=${SALESFORCE_SECURITY_TOKEN:-$4}
@@ -33,6 +34,31 @@ if [ -z "$SALESFORCE_SECURITY_TOKEN" ]
 then
      logerror "SALESFORCE_SECURITY_TOKEN is not set. Export it as environment variable or pass it as argument"
      exit 1
+fi
+
+
+# JWT_BEARER for the Bulk API connector arrived in 3.0.x; older artifacts only support the
+# username-password SOAP grant. Rather than duplicating this test per grant, or skipping it
+# on older artifacts, pick the grant from the version actually under test. An undeterminable
+# version falls back to username-password, which every version supports.
+SALESFORCE_CONNECTOR_VERSION="$(salesforce_connector_version)"
+if [ -n "$SALESFORCE_CONNECTOR_VERSION" ] && ! version_gt "3.0.0" "$SALESFORCE_CONNECTOR_VERSION"
+then
+  SALESFORCE_GRANT=JWT_BEARER
+else
+  SALESFORCE_GRANT=PASSWORD
+fi
+log "🔐 connector ${SALESFORCE_CONNECTOR_VERSION:-unknown} -> authenticating with $SALESFORCE_GRANT"
+
+if [ "$SALESFORCE_GRANT" = "JWT_BEARER" ]
+then
+  if [ -z "$SALESFORCE_CONSUMER_KEY_WITH_JWT" ]
+  then
+       logerror "SALESFORCE_CONSUMER_KEY_WITH_JWT is not set. Export it as environment variable or pass it as argument. Check README !"
+       exit 1
+  fi
+  # docker-compose.plaintext.yml already mounts the keystore into connect at /tmp.
+  salesforce_ensure_jwt_keystore "$PWD" > /dev/null
 fi
 
 PLAYGROUND_ENVIRONMENT=${PLAYGROUND_ENVIRONMENT:-"plaintext"}
@@ -120,6 +146,20 @@ restart_task_on_invalid_session() {
   return 1
 }
 
+
+if [ "$SALESFORCE_GRANT" = "JWT_BEARER" ]
+then
+  SALESFORCE_SOURCE_AUTH="\"salesforce.grant.type\" : \"JWT_BEARER\",
+     \"salesforce.username\" : \"$SALESFORCE_USERNAME\",
+     \"salesforce.consumer.key\" : \"$SALESFORCE_CONSUMER_KEY_WITH_JWT\",
+     \"salesforce.jwt.keystore.path\" : \"/tmp/salesforce-confluent.keystore.jks\",
+     \"salesforce.jwt.keystore.password\" : \"confluent\","
+else
+  SALESFORCE_SOURCE_AUTH="\"salesforce.username\" : \"$SALESFORCE_USERNAME\",
+     \"salesforce.password\" : \"$SALESFORCE_PASSWORD\",
+     \"salesforce.password.token\" : \"$SALESFORCE_SECURITY_TOKEN\","
+fi
+
 log "Creating Salesforce Bulk API Source connector"
 salesforce_create_connector_with_retry salesforce-bulkapi-source << EOF
 {
@@ -129,9 +169,7 @@ salesforce_create_connector_with_retry salesforce-bulkapi-source << EOF
      "curl.logging": "true",
      "salesforce.object" : "Lead",
      "salesforce.instance" : "$SALESFORCE_INSTANCE",
-     "salesforce.username" : "$SALESFORCE_USERNAME",
-     "salesforce.password" : "$SALESFORCE_PASSWORD",
-     "salesforce.password.token" : "$SALESFORCE_SECURITY_TOKEN",
+     $SALESFORCE_SOURCE_AUTH
      "connection.max.message.size": "10048576",
      "key.converter": "org.apache.kafka.connect.json.JsonConverter",
      "value.converter": "org.apache.kafka.connect.json.JsonConverter",
@@ -141,7 +179,12 @@ salesforce_create_connector_with_retry salesforce-bulkapi-source << EOF
 }
 EOF
 
-restart_task_on_invalid_session salesforce-bulkapi-source
+# Only the username-password grant shares one Salesforce session, so only it can have
+# its session torn down by validation's logout(). JWT takes a token per connection.
+if [ "$SALESFORCE_GRANT" = "PASSWORD" ]
+then
+  restart_task_on_invalid_session salesforce-bulkapi-source
+fi
 
 # 180s, not 60s: the Bulk API query job runs asynchronously on a Salesforce-side
 # queue, so how long it takes to complete is not under this test's control and

--- a/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source.sh
+++ b/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source.sh
@@ -39,12 +39,12 @@ PLAYGROUND_ENVIRONMENT=${PLAYGROUND_ENVIRONMENT:-"plaintext"}
 playground start-environment --environment "${PLAYGROUND_ENVIRONMENT}" --docker-compose-override-file "${PWD}/docker-compose.plaintext.yml"
 
 log "Login with sfdx CLI"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\""
 
 LEAD_FIRSTNAME=John_$RANDOM
 LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
-playground container exec --container sfdx-cli --command "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\"" --shell sh
+salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
 # Remove what this test created, so repeated runs do not accumulate records in a
 # shared Salesforce org. Only the exact Lead created above is matched, so a
@@ -53,7 +53,7 @@ playground container exec --container sfdx-cli --command "sfdx data:create:recor
 cleanup_salesforce_test_data() {
   set +e
   log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME"
-  playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" --shell sh << EOF
+  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 EOF
   set -e

--- a/connect/connect-salesforce-bulkapi-source/stop.sh
+++ b/connect/connect-salesforce-bulkapi-source/stop.sh
@@ -5,24 +5,18 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/../../scripts/utils.sh
 
-if [ ! -z "$GITHUB_RUN_NUMBER" ]
-then
-     # running with github actions
-
-
-
-    SALESFORCE_USERNAME=${SALESFORCE_USERNAME:-$1}
-    SALESFORCE_PASSWORD=${SALESFORCE_PASSWORD:-$2}
-    SALESFORCE_SECURITY_TOKEN=${SALESFORCE_SECURITY_TOKEN:-$5}
-    SALESFORCE_INSTANCE=${SALESFORCE_INSTANCE:-"https://login.salesforce.com"}
-
-    log "Login with sfdx CLI on the account #2"
-    playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\"" --shell sh
-
-    log "Bulk delete leads"
-    playground container exec --container sfdx-cli --command "sfdx data:query --target-org \"$SALESFORCE_USERNAME\" -q \"SELECT Id FROM Lead\" --result-format csv" --shell sh > /tmp/out.csv
-    playground container cp --source /tmp/out.csv --destination sfdx-cli:/tmp/out.csv
-    playground container exec --container sfdx-cli --command "sfdx force:data:bulk:delete --target-org \"$SALESFORCE_USERNAME\" -s Lead -f /tmp/out.csv" --shell sh
-fi
+# The teardown used to run:
+#   sfdx data:query -q "SELECT Id FROM Lead" --result-format csv > /tmp/out.csv
+#   sfdx force:data:bulk:delete -s Lead -f /tmp/out.csv
+# It has never worked. The redirect captures the CLI's own progress output
+# ("Querying Data... done", "Total number of records retrieved: N") into the CSV, so every
+# run ended in "InvalidBatch : Records not found" - observed on all four invocations of a
+# recent CI run. That is also why a shared org accumulated hundreds of stale Leads despite
+# an apparent "delete all Leads" teardown.
+#
+# It is removed rather than repaired: the query was unfiltered, so a working version would
+# delete EVERY Lead in the org including hand-made sample data. Each test already removes
+# exactly the records it created, in its own EXIT trap. A filtered sweep for leftovers from
+# aborted runs can be added separately, matching only the test naming patterns.
 
 stop_all "$DIR"

--- a/connect/connect-salesforce-cdc-source/salesforce-cdc-source-proxy.sh
+++ b/connect/connect-salesforce-cdc-source/salesforce-cdc-source-proxy.sh
@@ -85,12 +85,12 @@ EOF
 sleep 5
 
 log "Login with sfdx CLI"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\""
 
 log "Add a Contact to Salesforce"
-playground container exec --container sfdx-cli --command "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Contact -v \"FirstName='John_$RANDOM' LastName='Doe_$RANDOM'\"" --shell sh
+salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Contact -v \"FirstName='John_$RANDOM' LastName='Doe_$RANDOM'\""
 
 sleep 10
 
 log "Verify we have received the data in sfdc-cdc-contacts topic"
-playground topic consume --topic sfdc-cdc-contacts --min-expected-messages 1 --timeout 60
+playground topic consume --topic sfdc-cdc-contacts --min-expected-messages 1 --timeout 180

--- a/connect/connect-salesforce-cdc-source/salesforce-cdc-source.sh
+++ b/connect/connect-salesforce-cdc-source/salesforce-cdc-source.sh
@@ -87,14 +87,14 @@ EOF
 sleep 5
 
 log "Login with sfdx CLI"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\""
 
 # Captured in variables (rather than inlined) so the cleanup below can match the
 # exact Contact this run created.
 CONTACT_FIRSTNAME=John_$RANDOM
 CONTACT_LASTNAME=Doe_$RANDOM
 log "Add a Contact to Salesforce: $CONTACT_FIRSTNAME $CONTACT_LASTNAME"
-playground container exec --container sfdx-cli --command "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Contact -v \"FirstName='$CONTACT_FIRSTNAME' LastName='$CONTACT_LASTNAME'\"" --shell sh
+salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Contact -v \"FirstName='$CONTACT_FIRSTNAME' LastName='$CONTACT_LASTNAME'\""
 
 # Remove what this test created, so repeated runs do not accumulate records in a
 # shared Salesforce org. Only the exact Contact created above is matched, so a
@@ -103,7 +103,7 @@ playground container exec --container sfdx-cli --command "sfdx data:create:recor
 cleanup_salesforce_test_data() {
   set +e
   log "🧹 Cleaning up: Contact $CONTACT_FIRSTNAME $CONTACT_LASTNAME"
-  playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" --shell sh << EOF
+  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 Database.delete([SELECT Id FROM Contact WHERE FirstName = '$CONTACT_FIRSTNAME' AND LastName = '$CONTACT_LASTNAME'], false);
 EOF
   set -e
@@ -113,4 +113,4 @@ trap cleanup_salesforce_test_data EXIT
 sleep 10
 
 log "Verify we have received the data in sfdc-cdc-contacts topic"
-playground topic consume --topic sfdc-cdc-contacts --min-expected-messages 1 --timeout 60
+playground topic consume --topic sfdc-cdc-contacts --min-expected-messages 1 --timeout 180

--- a/connect/connect-salesforce-cdc-source/salesforce-cdc-source.sh
+++ b/connect/connect-salesforce-cdc-source/salesforce-cdc-source.sh
@@ -102,6 +102,7 @@ salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_
 # also happens when an assertion below fails.
 cleanup_salesforce_test_data() {
   set +e
+  salesforce_sfdx_relogin ""
   log "🧹 Cleaning up: Contact $CONTACT_FIRSTNAME $CONTACT_LASTNAME"
   salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 Database.delete([SELECT Id FROM Contact WHERE FirstName = '$CONTACT_FIRSTNAME' AND LastName = '$CONTACT_LASTNAME'], false);

--- a/connect/connect-salesforce-platform-events-sink/salesforce-platform-events-sink-proxy-basic-auth.sh
+++ b/connect/connect-salesforce-platform-events-sink/salesforce-platform-events-sink-proxy-basic-auth.sh
@@ -86,10 +86,10 @@ EOF
 sleep 5
 
 log "Login with sfdx CLI"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\""
 
 log "Send Platform Events"
-playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/event.apex\"" --shell sh
+salesforce_sfdx_with_retry "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/event.apex\""
 
 sleep 10
 
@@ -137,5 +137,5 @@ sleep 10
 log "Verify topic success-responses"
 playground topic consume --topic success-responses --min-expected-messages 2 --timeout 60
 
-# log "Verify topic error-responses"
-playground topic consume --topic error-responses --min-expected-messages 0 --timeout 60
+log "Verify the connector reported no errors"
+salesforce_assert_topic_empty error-responses

--- a/connect/connect-salesforce-platform-events-sink/salesforce-platform-events-sink-proxy.sh
+++ b/connect/connect-salesforce-platform-events-sink/salesforce-platform-events-sink-proxy.sh
@@ -82,10 +82,10 @@ EOF
 sleep 5
 
 log "Login with sfdx CLI"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\""
 
 log "Send Platform Events"
-playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/event.apex\"" --shell sh
+salesforce_sfdx_with_retry "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/event.apex\""
 
 sleep 10
 
@@ -130,5 +130,5 @@ sleep 10
 log "Verify topic success-responses"
 playground topic consume --topic success-responses --min-expected-messages 2 --timeout 60
 
-# log "Verify topic error-responses"
-playground topic consume --topic error-responses --min-expected-messages 0 --timeout 60
+log "Verify the connector reported no errors"
+salesforce_assert_topic_empty error-responses

--- a/connect/connect-salesforce-platform-events-sink/salesforce-platform-events-sink.sh
+++ b/connect/connect-salesforce-platform-events-sink/salesforce-platform-events-sink.sh
@@ -76,10 +76,10 @@ EOF
 sleep 5
 
 log "Login with sfdx CLI"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\""
 
 log "Send Platform Events"
-playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/event.apex\"" --shell sh
+salesforce_sfdx_with_retry "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/event.apex\""
 
 sleep 10
 
@@ -123,5 +123,5 @@ sleep 10
 log "Verify topic success-responses"
 playground topic consume --topic success-responses --min-expected-messages 2 --timeout 60
 
-# log "Verify topic error-responses"
-playground topic consume --topic error-responses --min-expected-messages 0 --timeout 60
+log "Verify the connector reported no errors"
+salesforce_assert_topic_empty error-responses

--- a/connect/connect-salesforce-platform-events-source/salesforce-platform-events-source-proxy.sh
+++ b/connect/connect-salesforce-platform-events-source/salesforce-platform-events-source-proxy.sh
@@ -83,10 +83,10 @@ EOF
 sleep 5
 
 log "Login with sfdx CLI"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\""
 
 log "Send Platform Events"
-playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/event.apex\"" --shell sh
+salesforce_sfdx_with_retry "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/event.apex\""
 
 sleep 10
 

--- a/connect/connect-salesforce-platform-events-source/salesforce-platform-events-source.sh
+++ b/connect/connect-salesforce-platform-events-source/salesforce-platform-events-source.sh
@@ -75,10 +75,10 @@ EOF
 sleep 5
 
 log "Login with sfdx CLI"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\""
 
 log "Send Platform Events"
-playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/event.apex\"" --shell sh
+salesforce_sfdx_with_retry "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/event.apex\""
 
 sleep 10
 

--- a/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy-basic-auth.sh
+++ b/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy-basic-auth.sh
@@ -64,17 +64,17 @@ PLAYGROUND_ENVIRONMENT=${PLAYGROUND_ENVIRONMENT:-"plaintext"}
 playground start-environment --environment "${PLAYGROUND_ENVIRONMENT}" --docker-compose-override-file "${PWD}/docker-compose.plaintext.proxy.basic-auth.yml"
 
 log "Login with sfdx CLI"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\""
 
 log "Delete $PUSH_TOPICS_NAME, if required"
 set +e
-playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" --shell sh << EOF
+salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 List<PushTopic> pts = [SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'];
 Database.delete(pts);
 EOF
 set -e
 log "Create $PUSH_TOPICS_NAME"
-playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/MyLeadPushTopics.apex\"" --shell sh
+salesforce_sfdx_with_retry "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/MyLeadPushTopics.apex\""
 
 DOMAIN=$(echo $SALESFORCE_INSTANCE | cut -d "/" -f 3)
 IP=$(nslookup $DOMAIN | grep Address | grep -v "#" | cut -d " " -f 2 | tail -1)
@@ -178,7 +178,7 @@ sleep 5
 LEAD_FIRSTNAME=John_$RANDOM
 LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
-playground container exec --container sfdx-cli --command "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\"" --shell sh
+salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
 sleep 30
 

--- a/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy.sh
+++ b/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy.sh
@@ -60,17 +60,17 @@ PLAYGROUND_ENVIRONMENT=${PLAYGROUND_ENVIRONMENT:-"plaintext"}
 playground start-environment --environment "${PLAYGROUND_ENVIRONMENT}" --docker-compose-override-file "${PWD}/docker-compose.plaintext.proxy.yml"
 
 log "Login with sfdx CLI"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\""
 
 log "Delete $PUSH_TOPICS_NAME, if required"
 set +e
-playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" --shell sh << EOF
+salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 List<PushTopic> pts = [SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'];
 Database.delete(pts);
 EOF
 set -e
 log "Create $PUSH_TOPICS_NAME"
-playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/MyLeadPushTopics.apex\"" --shell sh
+salesforce_sfdx_with_retry "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/MyLeadPushTopics.apex\""
 
 DOMAIN=$(echo $SALESFORCE_INSTANCE | cut -d "/" -f 3)
 IP=$(nslookup $DOMAIN | grep Address | grep -v "#" | cut -d " " -f 2 | tail -1)
@@ -108,7 +108,7 @@ sleep 5
 LEAD_FIRSTNAME=John_$RANDOM
 LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
-playground container exec --container sfdx-cli --command "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\"" --shell sh
+salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
 sleep 30
 

--- a/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source.sh
+++ b/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source.sh
@@ -115,6 +115,7 @@ salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_
 # assertion below fails.
 cleanup_salesforce_test_data() {
   set +e
+  salesforce_sfdx_relogin ""
   log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME and PushTopic $PUSH_TOPICS_NAME"
   salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);

--- a/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source.sh
+++ b/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source.sh
@@ -64,17 +64,17 @@ PLAYGROUND_ENVIRONMENT=${PLAYGROUND_ENVIRONMENT:-"plaintext"}
 playground start-environment --environment "${PLAYGROUND_ENVIRONMENT}" --docker-compose-override-file "${PWD}/docker-compose.plaintext.yml"
 
 log "Login with sfdx CLI"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\""
 
 log "Delete $PUSH_TOPICS_NAME, if required"
 set +e
-playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" --shell sh << EOF
+salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 List<PushTopic> pts = [SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'];
 Database.delete(pts);
 EOF
 set -e
 log "Create $PUSH_TOPICS_NAME"
-playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/MyLeadPushTopics.apex\"" --shell sh
+salesforce_sfdx_with_retry "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/MyLeadPushTopics.apex\""
 
 log "Creating Salesforce PushTopics Source connector"
 salesforce_create_connector_with_retry salesforce-pushtopic-source << EOF
@@ -106,7 +106,7 @@ sleep 5
 LEAD_FIRSTNAME=John_$RANDOM
 LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
-playground container exec --container sfdx-cli --command "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\"" --shell sh
+salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
 # Remove what this test created, so repeated runs do not accumulate records in a
 # shared Salesforce org (Developer Edition orgs have a hard storage limit).
@@ -116,7 +116,7 @@ playground container exec --container sfdx-cli --command "sfdx data:create:recor
 cleanup_salesforce_test_data() {
   set +e
   log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME and PushTopic $PUSH_TOPICS_NAME"
-  playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" --shell sh << EOF
+  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
 EOF

--- a/connect/connect-salesforce-pushtopics-source/stop.sh
+++ b/connect/connect-salesforce-pushtopics-source/stop.sh
@@ -5,24 +5,18 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/../../scripts/utils.sh
 
-if [ ! -z "$GITHUB_RUN_NUMBER" ]
-then
-     # running with github actions
-
-
-
-    SALESFORCE_USERNAME=${SALESFORCE_USERNAME:-$1}
-    SALESFORCE_PASSWORD=${SALESFORCE_PASSWORD:-$2}
-    SALESFORCE_SECURITY_TOKEN=${SALESFORCE_SECURITY_TOKEN:-$5}
-    SALESFORCE_INSTANCE=${SALESFORCE_INSTANCE:-"https://login.salesforce.com"}
-
-    log "Login with sfdx CLI on the account #2"
-    playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\"" --shell sh
-
-    log "Bulk delete leads"
-    playground container exec --container sfdx-cli --command "sfdx data:query --target-org \"$SALESFORCE_USERNAME\" -q \"SELECT Id FROM Lead\" --result-format csv" --shell sh > /tmp/out.csv
-    playground container cp --source /tmp/out.csv --destination sfdx-cli:/tmp/out.csv
-    playground container exec --container sfdx-cli --command "sfdx force:data:bulk:delete --target-org \"$SALESFORCE_USERNAME\" -s Lead -f /tmp/out.csv" --shell sh
-fi
+# The teardown used to run:
+#   sfdx data:query -q "SELECT Id FROM Lead" --result-format csv > /tmp/out.csv
+#   sfdx force:data:bulk:delete -s Lead -f /tmp/out.csv
+# It has never worked. The redirect captures the CLI's own progress output
+# ("Querying Data... done", "Total number of records retrieved: N") into the CSV, so every
+# run ended in "InvalidBatch : Records not found" - observed on all four invocations of a
+# recent CI run. That is also why a shared org accumulated hundreds of stale Leads despite
+# an apparent "delete all Leads" teardown.
+#
+# It is removed rather than repaired: the query was unfiltered, so a working version would
+# delete EVERY Lead in the org including hand-made sample data. Each test already removes
+# exactly the records it created, in its own EXIT trap. A filtered sweep for leftovers from
+# aborted runs can be added separately, matching only the test naming patterns.
 
 stop_all "$DIR"

--- a/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink-proxy.sh
+++ b/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink-proxy.sh
@@ -95,17 +95,17 @@ playground start-environment --environment "${PLAYGROUND_ENVIRONMENT}" --docker-
 # the Salesforce PushTopic source connector is used to get data into Kafka and the Salesforce SObject sink connector is used to export data from Kafka to Salesforce
 
 log "Login with sfdx CLI"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\""
 
 log "Delete $PUSH_TOPICS_NAME, if required"
 set +e
-playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" --shell sh << EOF
+salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 List<PushTopic> pts = [SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'];
 Database.delete(pts);
 EOF
 set -e
 log "Create $PUSH_TOPICS_NAME"
-playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/MyLeadPushTopics.apex\"" --shell sh
+salesforce_sfdx_with_retry "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/MyLeadPushTopics.apex\""
 
 DOMAIN=$(echo $SALESFORCE_INSTANCE | cut -d "/" -f 3)
 IP=$(nslookup $DOMAIN | grep Address | grep -v "#" | cut -d " " -f 2 | tail -1)
@@ -148,7 +148,7 @@ sleep 5
 LEAD_FIRSTNAME=John_$RANDOM
 LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
-playground container exec --container sfdx-cli --command "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\"" --shell sh
+salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
 sleep 30
 
@@ -195,11 +195,11 @@ sleep 10
 log "Verify topic success-responses"
 playground topic consume --topic success-responses --min-expected-messages 1 --timeout 60
 
-# log "Verify topic error-responses"
-playground topic consume --topic error-responses --min-expected-messages 0 --timeout 60
+log "Verify the connector reported no errors"
+salesforce_assert_topic_empty error-responses
 
 log "Login with sfdx CLI on the account #2"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME_ACCOUNT2\" -p \"$SALESFORCE_PASSWORD_ACCOUNT2\" -r \"$SALESFORCE_INSTANCE_ACCOUNT2\" -s \"$SALESFORCE_SECURITY_TOKEN_ACCOUNT2\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME_ACCOUNT2\" -p \"$SALESFORCE_PASSWORD_ACCOUNT2\" -r \"$SALESFORCE_INSTANCE_ACCOUNT2\" -s \"$SALESFORCE_SECURITY_TOKEN_ACCOUNT2\""
 
 log "Get the Lead created on account #2"
 # data:query, not data:record:get: the sink inserts (it never upserts), so a shared org
@@ -208,6 +208,6 @@ log "Get the Lead created on account #2"
 # record the test just wrote is present. data:query returns every match, and the grep
 # below still fails if the record is genuinely missing.
 # || true so cat always runs - without it set -e aborts here and the error is never shown.
-playground container exec --container sfdx-cli --command "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" --shell sh > /tmp/result.log 2>&1 || true
+salesforce_sfdx_with_retry "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" > /tmp/result.log 2>&1 || true
 cat /tmp/result.log
 grep "$LEAD_FIRSTNAME" /tmp/result.log

--- a/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink.sh
+++ b/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink.sh
@@ -150,6 +150,8 @@ salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_
 # because that org is not authenticated until later in the script.
 cleanup_salesforce_test_data() {
   set +e
+  salesforce_sfdx_relogin ""
+  salesforce_sfdx_relogin "_ACCOUNT2"
   log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME (both orgs) and PushTopic $PUSH_TOPICS_NAME"
   salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);

--- a/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink.sh
+++ b/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink.sh
@@ -97,17 +97,17 @@ playground start-environment --environment "${PLAYGROUND_ENVIRONMENT}" --docker-
 # the Salesforce PushTopic source connector is used to get data into Kafka and the Salesforce SObject sink connector is used to export data from Kafka to Salesforce
 
 log "Login with sfdx CLI"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\""
 
 log "Delete $PUSH_TOPICS_NAME, if required"
 set +e
-playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" --shell sh << EOF
+salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 List<PushTopic> pts = [SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'];
 Database.delete(pts);
 EOF
 set -e
 log "Create $PUSH_TOPICS_NAME"
-playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/MyLeadPushTopics.apex\"" --shell sh
+salesforce_sfdx_with_retry "sfdx apex run --target-org \"$SALESFORCE_USERNAME\" -f \"/tmp/MyLeadPushTopics.apex\""
 
 log "Creating Salesforce PushTopics Source connector"
 salesforce_create_connector_with_retry salesforce-pushtopic-source << EOF
@@ -139,7 +139,7 @@ sleep 5
 LEAD_FIRSTNAME=John_$RANDOM
 LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
-playground container exec --container sfdx-cli --command "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\"" --shell sh
+salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
 # Remove what this test created, so repeated runs do not accumulate records in
 # shared Salesforce orgs. This test writes to two orgs: the Lead seeded above in
@@ -151,11 +151,11 @@ playground container exec --container sfdx-cli --command "sfdx data:create:recor
 cleanup_salesforce_test_data() {
   set +e
   log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME (both orgs) and PushTopic $PUSH_TOPICS_NAME"
-  playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" --shell sh << EOF
+  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
 EOF
-  playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" --shell sh << EOF
+  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 EOF
   set -e
@@ -693,11 +693,11 @@ sleep 10
 log "Verify topic success-responses"
 playground topic consume --topic success-responses --min-expected-messages 1 --timeout 180
 
-# log "Verify topic error-responses"
-playground topic consume --topic error-responses --min-expected-messages 0 --timeout 60
+log "Verify the connector reported no errors"
+salesforce_assert_topic_empty error-responses
 
 log "Login with sfdx CLI on the account #2"
-playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME_ACCOUNT2\" -p \"$SALESFORCE_PASSWORD_ACCOUNT2\" -r \"$SALESFORCE_INSTANCE_ACCOUNT2\" -s \"$SALESFORCE_SECURITY_TOKEN_ACCOUNT2\"" --shell sh
+salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME_ACCOUNT2\" -p \"$SALESFORCE_PASSWORD_ACCOUNT2\" -r \"$SALESFORCE_INSTANCE_ACCOUNT2\" -s \"$SALESFORCE_SECURITY_TOKEN_ACCOUNT2\""
 
 log "Get the Lead created on account #2"
 # data:query, not data:record:get: the sink inserts (it never upserts), so a shared org
@@ -706,6 +706,6 @@ log "Get the Lead created on account #2"
 # record the test just wrote is present. data:query returns every match, and the grep
 # below still fails if the record is genuinely missing.
 # || true so cat always runs - without it set -e aborts here and the error is never shown.
-playground container exec --container sfdx-cli --command "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" --shell sh > /tmp/result.log 2>&1 || true
+salesforce_sfdx_with_retry "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" > /tmp/result.log 2>&1 || true
 cat /tmp/result.log
 grep "$LEAD_FIRSTNAME" /tmp/result.log

--- a/connect/connect-salesforce-sobject-sink/stop.sh
+++ b/connect/connect-salesforce-sobject-sink/stop.sh
@@ -5,24 +5,18 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/../../scripts/utils.sh
 
-if [ ! -z "$GITHUB_RUN_NUMBER" ]
-then
-     # running with github actions
-
-
-    # second account (for Bulk API sink)
-    SALESFORCE_USERNAME_ACCOUNT2=${SALESFORCE_USERNAME_ACCOUNT2:-$6}
-    SALESFORCE_PASSWORD_ACCOUNT2=${SALESFORCE_PASSWORD_ACCOUNT2:-$7}
-    SALESFORCE_SECURITY_TOKEN_ACCOUNT2=${SALESFORCE_SECURITY_TOKEN_ACCOUNT2:-$8}
-    SALESFORCE_INSTANCE_ACCOUNT2=${SALESFORCE_INSTANCE_ACCOUNT2:-"https://login.salesforce.com"}
-
-    log "Login with sfdx CLI on the account #2"
-    playground container exec --container sfdx-cli --command "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME_ACCOUNT2\" -p \"$SALESFORCE_PASSWORD_ACCOUNT2\" -r \"$SALESFORCE_INSTANCE_ACCOUNT2\" -s \"$SALESFORCE_SECURITY_TOKEN_ACCOUNT2\"" --shell sh
-
-    log "Bulk delete leads"
-    playground container exec --container sfdx-cli --command "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id FROM Lead\" --result-format csv" --shell sh > /tmp/out.csv
-    playground container cp --source /tmp/out.csv --destination sfdx-cli:/tmp/out.csv
-    playground container exec --container sfdx-cli --command "sfdx force:data:bulk:delete --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -s Lead -f /tmp/out.csv" --shell sh
-fi
+# The teardown used to run:
+#   sfdx data:query -q "SELECT Id FROM Lead" --result-format csv > /tmp/out.csv
+#   sfdx force:data:bulk:delete -s Lead -f /tmp/out.csv
+# It has never worked. The redirect captures the CLI's own progress output
+# ("Querying Data... done", "Total number of records retrieved: N") into the CSV, so every
+# run ended in "InvalidBatch : Records not found" - observed on all four invocations of a
+# recent CI run. That is also why a shared org accumulated hundreds of stale Leads despite
+# an apparent "delete all Leads" teardown.
+#
+# It is removed rather than repaired: the query was unfiltered, so a working version would
+# delete EVERY Lead in the org including hand-made sample data. Each test already removes
+# exactly the records it created, in its own EXIT trap. A filtered sweep for leftovers from
+# aborted runs can be added separately, matching only the test naming patterns.
 
 stop_all "$DIR"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -92,6 +92,32 @@ Read timed out|Connection reset|Connection refused|\
 SERVER_UNAVAILABLE|Server Unavailable|UNABLE_TO_LOCK_ROW|\
 INVALID_SESSION_ID}"
 
+# The same idea for the sfdx CLI steps (login, record create, Apex). These run before and
+# around the connector, and a blip in any of them aborts the test just as hard.
+#
+# "Could not retrieve the username after successful auth code exchange" is observed in CI:
+# sfpowerkit:auth:login failed with it, and the identical login with the identical
+# credentials succeeded 15 seconds later in the same test's teardown - so it is transient.
+SALESFORCE_TRANSIENT_SFDX_ERRORS="${SALESFORCE_TRANSIENT_SFDX_ERRORS:-\
+Could not retrieve the username after successful auth code exchange|\
+Session expired or invalid|INVALID_SESSION_ID|Bad_OAuth_Token|\
+Read timed out|Connection reset|Connection refused|ETIMEDOUT|ECONNRESET|EAI_AGAIN|\
+socket hang up|502 Bad Gateway|503 Service Unavailable|504 Gateway|\
+SERVER_UNAVAILABLE|Server Unavailable|UNABLE_TO_LOCK_ROW}"
+
+# Errors that must NEVER be retried, checked before the transient lists above.
+#
+# REQUEST_LIMIT_EXCEEDED is the org's 24h API request cap. Retrying spends more of the
+# very budget that is exhausted, and when it hits, every test fails at once - which looks
+# exactly like a session bug unless it is called out explicitly.
+#
+# DUPLICATES_DETECTED and the *_REQUIRED_FIELD / INVALID_FIELD family are deterministic:
+# the same request will fail the same way however many times it is sent.
+SALESFORCE_FATAL_ERRORS="${SALESFORCE_FATAL_ERRORS:-\
+REQUEST_LIMIT_EXCEEDED|TotalRequests Limit exceeded|\
+DUPLICATES_DETECTED|REQUIRED_FIELD_MISSING|INVALID_FIELD|\
+INSUFFICIENT_ACCESS|INVALID_LOGIN}"
+
 # Retries consumed so far by this test. Reset per test process, since each test runs in
 # its own shell - so the budget below is genuinely per test, not per connector.
 SALESFORCE_CREATE_RETRIES_USED=0
@@ -151,6 +177,12 @@ function salesforce_create_connector_with_retry() {
       return 0
     fi
 
+    if echo "$out" | grep -qE "$SALESFORCE_FATAL_ERRORS"
+    then
+      logerror "❌ $connector creation hit a limit or a deterministic rejection that retrying cannot fix, not retrying"
+      return $rc
+    fi
+
     if ! echo "$out" | grep -qE "$SALESFORCE_TRANSIENT_CREATE_ERRORS"
     then
       logerror "❌ $connector creation failed for a non-transient reason, not retrying"
@@ -168,6 +200,129 @@ function salesforce_create_connector_with_retry() {
     sleep "$delay"
     attempt=$((attempt + 1))
   done
+}
+
+# Run an sfdx command in the sfdx-cli container, retrying only on a transient failure.
+#
+# Every sfdx step in these tests runs under `set -e`, so a single blip in a login, a record
+# create or an Apex run aborts the test even though nothing is wrong with the connector.
+# Only connector creation was retried before this; the steps around it were not.
+#
+# Usage mirrors the call it replaces:
+#
+#   salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$USER\" ..."
+#
+# and for the commands that pipe Apex in on stdin:
+#
+#   salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$USER\"" << EOF
+#   Database.delete(...);
+#   EOF
+#
+# The retry budget is shared with salesforce_create_connector_with_retry, so
+# SALESFORCE_CREATE_MAX_RETRIES is the ceiling for the whole test, not per step.
+function salesforce_sfdx_with_retry() {
+  local use_stdin=0
+
+  if [ "$1" == "--stdin" ]
+  then
+    use_stdin=1
+    shift
+  fi
+
+  local sfdx_command="$1"
+  local label="${2:-$(echo "$sfdx_command" | awk '{print $1" "$2}')}"
+  local max_retries="${SALESFORCE_CREATE_MAX_RETRIES:-3}"
+  local delay="${SALESFORCE_CREATE_RETRY_DELAY:-15}"
+  local body="" attempt=1 rc out had_errexit=0
+
+  # As in salesforce_create_connector_with_retry: restore the caller's errexit exactly,
+  # because the cleanup traps deliberately run with it off.
+  case $- in
+    *e*) had_errexit=1 ;;
+  esac
+
+  if [ $use_stdin -eq 1 ]
+  then
+    body="$(cat)"
+  fi
+
+  while true
+  do
+    set +e
+    if [ $use_stdin -eq 1 ]
+    then
+      out="$(printf '%s\n' "$body" | playground container exec --container sfdx-cli --command "$sfdx_command" --shell sh 2>&1)"
+    else
+      out="$(playground container exec --container sfdx-cli --command "$sfdx_command" --shell sh 2>&1)"
+    fi
+    rc=$?
+    if [ $had_errexit -eq 1 ]
+    then
+      set -e
+    fi
+    echo "$out"
+
+    if [ $rc -eq 0 ]
+    then
+      if [ $attempt -gt 1 ]
+      then
+        log "✅ $label succeeded on attempt $attempt"
+      fi
+      return 0
+    fi
+
+    if echo "$out" | grep -qE "$SALESFORCE_FATAL_ERRORS"
+    then
+      logerror "❌ $label hit a limit or a deterministic rejection that retrying cannot fix, not retrying"
+      return $rc
+    fi
+
+    if ! echo "$out" | grep -qE "$SALESFORCE_TRANSIENT_SFDX_ERRORS"
+    then
+      logerror "❌ $label failed for a non-transient reason, not retrying"
+      return $rc
+    fi
+
+    if [ "$SALESFORCE_CREATE_RETRIES_USED" -ge "$max_retries" ]
+    then
+      logerror "❌ $label hit a transient error but this test has already used its $max_retries retry(ies)"
+      return $rc
+    fi
+
+    SALESFORCE_CREATE_RETRIES_USED=$((SALESFORCE_CREATE_RETRIES_USED + 1))
+    logwarn "⚠️ transient error during $label, retrying in ${delay}s (retry $SALESFORCE_CREATE_RETRIES_USED/$max_retries for this test)"
+    sleep "$delay"
+    attempt=$((attempt + 1))
+  done
+}
+
+# Assert a topic is empty, and fail the test if it is not.
+#
+# `playground topic consume --min-expected-messages 0` does NOT assert anything: with 0 the
+# CLI skips its count check entirely and only warns when the topic is missing. The sink
+# tests used it for error-responses, so a partial failure (one good record plus N errored
+# ones) satisfied "success-responses >= 1" and the errors were never looked at.
+function salesforce_assert_topic_empty() {
+  local topic="$1"
+  local nb_messages=""
+
+  nb_messages=$(playground topic get-number-records -t "$topic" 2>/dev/null | tail -1)
+
+  # A topic that was never created means the connector produced no errors at all.
+  if [[ ! "$nb_messages" =~ ^[0-9]+$ ]]
+  then
+    log "✅ topic $topic contains no records (topic was never created)"
+    return 0
+  fi
+
+  if [ "$nb_messages" -gt 0 ]
+  then
+    logerror "❌ topic $topic should be empty but contains $nb_messages message(s)"
+    playground topic consume --topic "$topic" --max-messages -1 || true
+    return 1
+  fi
+
+  log "✅ topic $topic is empty, as expected"
 }
 
 function salesforce_ensure_jwt_keystore() {

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -296,6 +296,35 @@ function salesforce_sfdx_with_retry() {
   done
 }
 
+# Re-authenticate the sfdx CLI for one account. Pass "" for the primary account or
+# "_ACCOUNT2" for the second.
+#
+# Cleanup needs this. A connector on the username-password SOAP grant ends its session with
+# logout() during validation, and Salesforce reuses one session across identical logins by
+# the same user - so it also kills the session the sfdx CLI is holding. By the time the EXIT
+# trap runs, `sfdx apex run` fails with "Session expired or invalid" and the test's records
+# are never deleted. Retrying cannot help: re-running the command does not re-authenticate.
+#
+# Observed locally on CP 8.3.0: salesforce-bulkapi-source and
+# salesforce-bulkapi-sink-with-bulkapi-source each burned all three retries on the cleanup
+# Apex and still left their Lead behind. The five tests whose connectors use JWT were
+# unaffected. Re-authenticating restores what KDP commit 478e93a5 removed.
+function salesforce_sfdx_relogin() {
+  local suffix="${1:-}"
+  local uv="SALESFORCE_USERNAME${suffix}" pv="SALESFORCE_PASSWORD${suffix}"
+  local tv="SALESFORCE_SECURITY_TOKEN${suffix}" iv="SALESFORCE_INSTANCE${suffix}"
+  local u="${!uv}" p="${!pv}" t="${!tv}" i="${!iv:-https://login.salesforce.com}"
+
+  if [ -z "$u" ] || [ -z "$p" ] || [ -z "$t" ]
+  then
+    logwarn "⚠️ cannot re-authenticate sfdx for account '${suffix:-primary}', credentials not set"
+    return 1
+  fi
+
+  log "🔑 Re-authenticating sfdx for $u before cleanup"
+  salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$u\" -p \"$p\" -r \"$i\" -s \"$t\""
+}
+
 # Assert a topic is empty, and fail the test if it is not.
 #
 # `playground topic consume --min-expected-messages 0` does NOT assert anything: with 0 the

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -354,6 +354,37 @@ function salesforce_assert_topic_empty() {
   log "✅ topic $topic is empty, as expected"
 }
 
+# Version of the connector actually under test, or "" when it cannot be determined.
+#
+# --connector-tag runs set CONNECTOR_TAG, but --connector-zip and --connector-jar runs do
+# NOT: utils.sh only assigns CONNECTOR_TAG on the path where neither is set. CI gates build
+# the connector from the PR branch and pass --connector-zip, so CONNECTOR_TAG is empty there
+# and any guard written as `[ ! -z "$CONNECTOR_TAG" ] && ...` silently never fires. The
+# version is still available - in the artifact filename, e.g.
+# confluentinc-kafka-connect-salesforce-bulk-api-3.0.15-SNAPSHOT.zip
+function salesforce_connector_version() {
+  local artifact=""
+
+  if [ ! -z "$CONNECTOR_TAG" ]
+  then
+    echo "$CONNECTOR_TAG"
+    return 0
+  fi
+
+  if [ ! -z "$CONNECTOR_ZIP" ]
+  then
+    artifact="$(basename "$CONNECTOR_ZIP")"
+  elif [ ! -z "$CONNECTOR_JAR" ]
+  then
+    artifact="$(basename "$CONNECTOR_JAR")"
+  else
+    return 0
+  fi
+
+  # Trailing -SNAPSHOT is dropped so the result compares cleanly with a plain x.y.z bound.
+  echo "$artifact" | sed -nE 's/.*[-_]([0-9]+\.[0-9]+\.[0-9]+)(-SNAPSHOT)?\.(zip|jar)$/\1/p'
+}
+
 function salesforce_ensure_jwt_keystore() {
   local target_dir="${1:-$PWD}"
   local keystore_path="$target_dir/salesforce-confluent.keystore.jks"


### PR DESCRIPTION
> Stacked on #8749 — the first two commits here are that PR. Review/merge #8749 first; this diff is the third commit.

JWT_BEARER support for the Bulk API connector landed in confluentinc/kafka-connect-salesforce#882 on `3.0.x`. It is not on `2.0.x`, which is also a PR-gated branch.

Rather than duplicating each test per grant, the two existing Bulk API tests pick the grant from the version of the artifact actually under test:

```bash
SALESFORCE_CONNECTOR_VERSION="$(salesforce_connector_version)"
if [ -n "$SALESFORCE_CONNECTOR_VERSION" ] && ! version_gt "3.0.0" "$SALESFORCE_CONNECTOR_VERSION"
then
  SALESFORCE_GRANT=JWT_BEARER
else
  SALESFORCE_GRANT=PASSWORD
fi
```

This mirrors how the other five Salesforce connectors already work — each uses JWT inline in its main test. There are no `*-jwt-flow.sh` files in this repo, so a separate test per grant would not have matched the existing convention.

### Why the version has to come from the artifact

The tests already carry a connector-version guard:

```bash
if connect_cp_version_greater_than_8 && [ ! -z "$CONNECTOR_TAG" ] && ! version_gt $CONNECTOR_TAG "2.0.28"
```

That `[ ! -z "$CONNECTOR_TAG" ]` makes it a no-op in CI. `utils.sh` only assigns `CONNECTOR_TAG` on the path where **neither** `CONNECTOR_ZIP` nor `CONNECTOR_JAR` is set, and CI gates build from the PR branch and pass `--connector-zip`. The version is still available in the artifact filename, which is what `salesforce_connector_version` reads:

```
confluentinc-kafka-connect-salesforce-bulk-api-3.0.15-SNAPSHOT.zip
```

An undeterminable version falls back to username-password, which every version supports, so the test cannot fail closed.

### Knock-on simplifications

- **No test skips**, so kafka-docker-playground's `exit 111` signal is not involved. The PR-gating pipelines need **no change** — an earlier revision of this PR required one, and that is no longer necessary.
- **`plugin-test-mapping.json` needs no new entries.** The two existing Bulk API tests simply authenticate differently depending on the branch they run against.
- The `INVALID_SESSION_ID` task-restart workaround is now **conditional on the password grant**. It exists because that grant shares one Salesforce session across identical logins by the same user, so connector validation's `logout()` can tear down the session the task holds. JWT takes a token per connection, and the five connectors already on JWT have never hit it.

### Trade-off

On `3.0.x` and later these tests no longer cover the Bulk API **password** grant. `2.0.x` still exercises it, and the grant is retired in Winter '27, but a password-path regression on `3.0.x` would not be caught here. If that coverage is wanted, it should be an additional test rather than a reason to duplicate these.

### Validation

Run locally in both directions, source and sink, against real artifacts built from each branch. Credentials from the same Vault path the gate uses.

| Artifact | Grant selected | `bulkapi-source` | `bulkapi-sink-with-bulkapi-source` |
|---|---|---|---|
| `3.0.15-SNAPSHOT` (3.0.x) on CP 8.3.0 | **JWT_BEARER** | ✅ PASSED 76s | ✅ PASSED 149s |
| `2.0.41-SNAPSHOT` (2.0.x) on CP 7.9.0 | **PASSWORD** | ✅ PASSED 94s | ✅ PASSED 166s |

Log lines confirming the selection:

```
🔐 connector 3.0.15 -> authenticating with JWT_BEARER
🔐 connector 2.0.41 -> authenticating with PASSWORD
```

`retries=0` on all four. The sink case also covers the two-account path — source authenticating to the first org, sink to the second, both under the selected grant.
