### PR TITLE
Salesforce: fix assertions that could pass without checking, and cleanup that never ran

### DIFF
--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source-proxy.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source-proxy.sh
@@ -80,6 +80,35 @@ LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
 salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
+# Remove what this test created, so repeated runs do not accumulate records in a shared
+# Salesforce org. Only the exact records created above are matched. An EXIT trap so cleanup
+# also happens when an assertion fails.
+cleanup_salesforce_test_data() {
+  set +e
+  # Cleanup gets its own retry allowance: the test body may already have spent the shared
+  # budget, and with two orgs the first delete could otherwise leave the second with a
+  # single attempt.
+  SALESFORCE_CREATE_RETRIES_USED=0
+  local cleanup_failed=0
+  salesforce_sfdx_relogin ""
+  salesforce_sfdx_relogin "_ACCOUNT2"
+  log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME (both orgs)"
+  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
+Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
+EOF
+  [ $? -ne 0 ] && cleanup_failed=1
+  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" << EOF
+Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
+EOF
+  [ $? -ne 0 ] && cleanup_failed=1
+  if [ $cleanup_failed -ne 0 ]
+  then
+    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
+  fi
+  set -e
+}
+trap cleanup_salesforce_test_data EXIT
+
 DOMAIN=$(echo $SALESFORCE_INSTANCE | cut -d "/" -f 3)
 IP=$(nslookup $DOMAIN | grep Address | grep -v "#" | cut -d " " -f 2 | tail -1)
 log "Blocking $DOMAIN IP $IP to make sure proxy is used"

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source-proxy.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source-proxy.sh
@@ -97,6 +97,9 @@ cleanup_salesforce_test_data() {
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 EOF
   [ $? -ne 0 ] && cleanup_failed=1
+  # A second reset: without it the first org's delete can spend the whole allowance and
+  # leave this one a single attempt.
+  SALESFORCE_CREATE_RETRIES_USED=0
   salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 EOF

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source-proxy.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source-proxy.sh
@@ -80,34 +80,15 @@ LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
 salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
-# Remove what this test created, so repeated runs do not accumulate records in a shared
-# Salesforce org. Only the exact records created above are matched. An EXIT trap so cleanup
-# also happens when an assertion fails.
+# Remove the records this test created, so repeated runs do not accumulate data in a
+# shared Salesforce org. Only the exact records created above are matched. An EXIT trap,
+# so cleanup also happens when an assertion fails.
 cleanup_salesforce_test_data() {
   set +e
-  # Cleanup gets its own retry allowance: the test body may already have spent the shared
-  # budget, and with two orgs the first delete could otherwise leave the second with a
-  # single attempt.
-  SALESFORCE_CREATE_RETRIES_USED=0
-  local cleanup_failed=0
-  salesforce_sfdx_relogin ""
-  salesforce_sfdx_relogin "_ACCOUNT2"
-  log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME (both orgs)"
-  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
-Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
-EOF
-  [ $? -ne 0 ] && cleanup_failed=1
-  # A second reset: without it the first org's delete can spend the whole allowance and
-  # leave this one a single attempt.
-  SALESFORCE_CREATE_RETRIES_USED=0
-  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" << EOF
-Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
-EOF
-  [ $? -ne 0 ] && cleanup_failed=1
-  if [ $cleanup_failed -ne 0 ]
-  then
-    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
-  fi
+  salesforce_cleanup_records "$SALESFORCE_USERNAME" "$SALESFORCE_PASSWORD" "$SALESFORCE_SECURITY_TOKEN" "$SALESFORCE_INSTANCE" \
+    "Lead:FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'"
+  salesforce_cleanup_records "$SALESFORCE_USERNAME_ACCOUNT2" "$SALESFORCE_PASSWORD_ACCOUNT2" "$SALESFORCE_SECURITY_TOKEN_ACCOUNT2" "$SALESFORCE_INSTANCE_ACCOUNT2" \
+    "Lead:FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'"
   set -e
 }
 trap cleanup_salesforce_test_data EXIT
@@ -204,6 +185,6 @@ log "Get the Lead created on account #2"
 # record the test just wrote is present. data:query returns every match, and the grep
 # below still fails if the record is genuinely missing.
 # || true so cat always runs - without it set -e aborts here and the error is never shown.
-salesforce_sfdx_with_retry "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" > /tmp/result.log 2>&1 || true
+playground container exec --container sfdx-cli --command "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" --shell sh > /tmp/result.log 2>&1 || true
 cat /tmp/result.log
 grep "$LEAD_FIRSTNAME" /tmp/result.log

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source.sh
@@ -153,6 +153,9 @@ Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND Las
 Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
 EOF
   [ $? -ne 0 ] && cleanup_failed=1
+  # A second reset: without it the first org's delete can spend the whole allowance and
+  # leave this one a single attempt.
+  SALESFORCE_CREATE_RETRIES_USED=0
   salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 EOF

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source.sh
@@ -232,7 +232,13 @@ salesforce_create_connector_with_retry salesforce-bulkapi-source << EOF
 }
 EOF
 
-if [ "$SALESFORCE_GRANT" = "PASSWORD" ]; then restart_task_on_invalid_session salesforce-bulkapi-source; fi
+# Called for both grants. Despite its name this is also the only place this test asserts
+# the task reached RUNNING: it fails with the task's stack trace on any other FAILED
+# state, and fails if the task never comes up within 120s. Gating it on the password
+# grant removed that assertion from the JWT path - the path CI takes - leaving a genuine
+# task failure to surface only as "topic contains 0 messages" with no trace. Its
+# INVALID_SESSION_ID branch simply never fires under JWT.
+restart_task_on_invalid_session salesforce-bulkapi-source
 
 # 180s, not 60s: the Bulk API query job runs asynchronously on a Salesforce-side
 # queue, so its completion time is not under this test's control.
@@ -269,7 +275,13 @@ salesforce_create_connector_with_retry salesforce-bulkapi-sink << EOF
 }
 EOF
 
-if [ "$SALESFORCE_GRANT" = "PASSWORD" ]; then restart_task_on_invalid_session salesforce-bulkapi-sink; fi
+# Called for both grants. Despite its name this is also the only place this test asserts
+# the task reached RUNNING: it fails with the task's stack trace on any other FAILED
+# state, and fails if the task never comes up within 120s. Gating it on the password
+# grant removed that assertion from the JWT path - the path CI takes - leaving a genuine
+# task failure to surface only as "topic contains 0 messages" with no trace. Its
+# INVALID_SESSION_ID branch simply never fires under JWT.
+restart_task_on_invalid_session salesforce-bulkapi-sink
 
 sleep 30
 

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source.sh
@@ -140,6 +140,11 @@ salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_
 # because that org is not authenticated until later in the script.
 cleanup_salesforce_test_data() {
   set +e
+  # Cleanup gets its own retry allowance: the test body may already have spent the shared
+  # budget, and with two orgs the first delete could otherwise leave the second with a
+  # single attempt.
+  SALESFORCE_CREATE_RETRIES_USED=0
+  local cleanup_failed=0
   salesforce_sfdx_relogin ""
   salesforce_sfdx_relogin "_ACCOUNT2"
   log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME (both orgs) and PushTopic $PUSH_TOPICS_NAME"
@@ -147,9 +152,15 @@ cleanup_salesforce_test_data() {
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
 EOF
+  [ $? -ne 0 ] && cleanup_failed=1
   salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 EOF
+  [ $? -ne 0 ] && cleanup_failed=1
+  if [ $cleanup_failed -ne 0 ]
+  then
+    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
+  fi
   set -e
 }
 trap cleanup_salesforce_test_data EXIT

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-bulkapi-source.sh
@@ -131,101 +131,20 @@ LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
 salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
-# Remove what this test created, so repeated runs do not accumulate records in
-# shared Salesforce orgs. This test writes to two orgs: the Lead seeded above in
-# the source org, and the Lead the sink writes into the ACCOUNT2 org (same
-# FirstName/LastName), plus the PushTopic. Only exact matches are deleted, so a
-# concurrent test's data is never touched. Registered as an EXIT trap so cleanup
-# also happens when an assertion below fails; the ACCOUNT2 delete is best-effort
-# because that org is not authenticated until later in the script.
+# Remove the records this test created, so repeated runs do not accumulate data in a
+# shared Salesforce org. Only the exact records created above are matched. An EXIT trap,
+# so cleanup also happens when an assertion fails.
 cleanup_salesforce_test_data() {
   set +e
-  # Cleanup gets its own retry allowance: the test body may already have spent the shared
-  # budget, and with two orgs the first delete could otherwise leave the second with a
-  # single attempt.
-  SALESFORCE_CREATE_RETRIES_USED=0
-  local cleanup_failed=0
-  salesforce_sfdx_relogin ""
-  salesforce_sfdx_relogin "_ACCOUNT2"
-  log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME (both orgs) and PushTopic $PUSH_TOPICS_NAME"
-  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
-Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
-Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
-EOF
-  [ $? -ne 0 ] && cleanup_failed=1
-  # A second reset: without it the first org's delete can spend the whole allowance and
-  # leave this one a single attempt.
-  SALESFORCE_CREATE_RETRIES_USED=0
-  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" << EOF
-Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
-EOF
-  [ $? -ne 0 ] && cleanup_failed=1
-  if [ $cleanup_failed -ne 0 ]
-  then
-    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
-  fi
+  salesforce_cleanup_records "$SALESFORCE_USERNAME" "$SALESFORCE_PASSWORD" "$SALESFORCE_SECURITY_TOKEN" "$SALESFORCE_INSTANCE" \
+    "Lead:FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'" \
+    "PushTopic:Name = '$PUSH_TOPICS_NAME'"
+  salesforce_cleanup_records "$SALESFORCE_USERNAME_ACCOUNT2" "$SALESFORCE_PASSWORD_ACCOUNT2" "$SALESFORCE_SECURITY_TOKEN_ACCOUNT2" "$SALESFORCE_INSTANCE_ACCOUNT2" \
+    "Lead:FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'"
   set -e
 }
 trap cleanup_salesforce_test_data EXIT
 
-# Wait for the connector's task to reach RUNNING, restarting it if it died with
-# INVALID_SESSION_ID.
-#
-# The Bulk API connectors authenticate with the username-password SOAP grant. Connector
-# validation opens its own PartnerConnection and ends it with a SOAP logout(), and
-# Salesforce reuses one session across identical logins by the same user - so validation
-# can tear down the session the task is holding. The task then fails its very first
-# describeSObject with INVALID_SESSION_ID ("Session not found, missing session hash")
-# within seconds of starting, and Connect does not retry a task that threw from start().
-#
-# Restarting the task re-authenticates without re-running validation, which is also the
-# remedy Salesforce documents for a session invalidated by a concurrent logout. Only
-# INVALID_SESSION_ID is retried: any other task failure fails the test immediately, so a
-# genuine regression is still caught.
-restart_task_on_invalid_session() {
-  local connector="$1"
-  local max_restarts="${2:-2}"
-  local restarts=0
-  local checks=0
-  local task_status state trace
-
-  while [ "$checks" -lt 12 ]; do
-    sleep 10
-    checks=$((checks + 1))
-    task_status=$(curl -s "http://localhost:8083/connectors/${connector}/status")
-    state=$(echo "$task_status" | jq -r '.tasks[0].state // "MISSING"')
-
-    case "$state" in
-      RUNNING)
-        if [ "$restarts" -gt 0 ]; then
-          log "✅ $connector task reached RUNNING after $restarts restart(s)"
-        fi
-        return 0
-        ;;
-      FAILED)
-        trace=$(echo "$task_status" | jq -r '.tasks[0].trace // ""')
-        if ! echo "$trace" | grep -q "INVALID_SESSION_ID"; then
-          logerror "$connector task FAILED, and not with INVALID_SESSION_ID:"
-          echo "$trace" | head -20
-          return 1
-        fi
-        if [ "$restarts" -ge "$max_restarts" ]; then
-          logerror "$connector still hitting INVALID_SESSION_ID after $restarts restart(s)"
-          return 1
-        fi
-        restarts=$((restarts + 1))
-        logwarn "⚠️ $connector hit INVALID_SESSION_ID, restarting task ($restarts/$max_restarts)"
-        curl -s -X POST "http://localhost:8083/connectors/${connector}/tasks/0/restart" > /dev/null
-        ;;
-      *)
-        # UNASSIGNED or not yet reported while the task is still coming up.
-        ;;
-    esac
-  done
-
-  logerror "$connector task never reached RUNNING (last state: $state)"
-  return 1
-}
 
 log "Creating Salesforce Bulk API Source connector"
 salesforce_create_connector_with_retry salesforce-bulkapi-source << EOF
@@ -320,6 +239,6 @@ log "Get the Lead created on account #2"
 # record the test just wrote is present. data:query returns every match, and the grep
 # below still fails if the record is genuinely missing.
 # || true so cat always runs - without it set -e aborts here and the error is never shown.
-salesforce_sfdx_with_retry "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" > /tmp/result.log 2>&1 || true
+playground container exec --container sfdx-cli --command "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" --shell sh > /tmp/result.log 2>&1 || true
 cat /tmp/result.log
 grep "$LEAD_FIRSTNAME" /tmp/result.log

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source-proxy.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source-proxy.sh
@@ -163,6 +163,9 @@ Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND Las
 Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
 EOF
   [ $? -ne 0 ] && cleanup_failed=1
+  # A second reset: without it the first org's delete can spend the whole allowance and
+  # leave this one a single attempt.
+  SALESFORCE_CREATE_RETRIES_USED=0
   salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 EOF

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source-proxy.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source-proxy.sh
@@ -145,6 +145,36 @@ LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
 salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
+# Remove what this test created, so repeated runs do not accumulate records in a shared
+# Salesforce org. Only the exact records created above are matched. An EXIT trap so cleanup
+# also happens when an assertion fails.
+cleanup_salesforce_test_data() {
+  set +e
+  # Cleanup gets its own retry allowance: the test body may already have spent the shared
+  # budget, and with two orgs the first delete could otherwise leave the second with a
+  # single attempt.
+  SALESFORCE_CREATE_RETRIES_USED=0
+  local cleanup_failed=0
+  salesforce_sfdx_relogin ""
+  salesforce_sfdx_relogin "_ACCOUNT2"
+  log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME (both orgs) and PushTopic $PUSH_TOPICS_NAME"
+  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
+Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
+Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
+EOF
+  [ $? -ne 0 ] && cleanup_failed=1
+  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" << EOF
+Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
+EOF
+  [ $? -ne 0 ] && cleanup_failed=1
+  if [ $cleanup_failed -ne 0 ]
+  then
+    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
+  fi
+  set -e
+}
+trap cleanup_salesforce_test_data EXIT
+
 
 sleep 30
 

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source-proxy.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source-proxy.sh
@@ -145,35 +145,16 @@ LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
 salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
-# Remove what this test created, so repeated runs do not accumulate records in a shared
-# Salesforce org. Only the exact records created above are matched. An EXIT trap so cleanup
-# also happens when an assertion fails.
+# Remove the records this test created, so repeated runs do not accumulate data in a
+# shared Salesforce org. Only the exact records created above are matched. An EXIT trap,
+# so cleanup also happens when an assertion fails.
 cleanup_salesforce_test_data() {
   set +e
-  # Cleanup gets its own retry allowance: the test body may already have spent the shared
-  # budget, and with two orgs the first delete could otherwise leave the second with a
-  # single attempt.
-  SALESFORCE_CREATE_RETRIES_USED=0
-  local cleanup_failed=0
-  salesforce_sfdx_relogin ""
-  salesforce_sfdx_relogin "_ACCOUNT2"
-  log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME (both orgs) and PushTopic $PUSH_TOPICS_NAME"
-  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
-Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
-Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
-EOF
-  [ $? -ne 0 ] && cleanup_failed=1
-  # A second reset: without it the first org's delete can spend the whole allowance and
-  # leave this one a single attempt.
-  SALESFORCE_CREATE_RETRIES_USED=0
-  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" << EOF
-Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
-EOF
-  [ $? -ne 0 ] && cleanup_failed=1
-  if [ $cleanup_failed -ne 0 ]
-  then
-    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
-  fi
+  salesforce_cleanup_records "$SALESFORCE_USERNAME" "$SALESFORCE_PASSWORD" "$SALESFORCE_SECURITY_TOKEN" "$SALESFORCE_INSTANCE" \
+    "Lead:FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'" \
+    "PushTopic:Name = '$PUSH_TOPICS_NAME'"
+  salesforce_cleanup_records "$SALESFORCE_USERNAME_ACCOUNT2" "$SALESFORCE_PASSWORD_ACCOUNT2" "$SALESFORCE_SECURITY_TOKEN_ACCOUNT2" "$SALESFORCE_INSTANCE_ACCOUNT2" \
+    "Lead:FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'"
   set -e
 }
 trap cleanup_salesforce_test_data EXIT
@@ -234,6 +215,6 @@ log "Get the Lead created on account #2"
 # record the test just wrote is present. data:query returns every match, and the grep
 # below still fails if the record is genuinely missing.
 # || true so cat always runs - without it set -e aborts here and the error is never shown.
-salesforce_sfdx_with_retry "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" > /tmp/result.log 2>&1 || true
+playground container exec --container sfdx-cli --command "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" --shell sh > /tmp/result.log 2>&1 || true
 cat /tmp/result.log
 grep "$LEAD_FIRSTNAME" /tmp/result.log

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source-proxy.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source-proxy.sh
@@ -91,7 +91,10 @@ salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME
 
 log "Delete $PUSH_TOPICS_NAME, if required"
 set +e
-salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
+# Expected to fail when the PushTopic does not exist yet, so deliberately NOT routed
+# through salesforce_sfdx_with_retry: retrying a step whose failure is normal would
+# spend this test's shared retry budget, and trigger a pointless re-authentication.
+playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF --shell sh
 List<PushTopic> pts = [SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'];
 Database.delete(pts);
 EOF

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source.sh
@@ -134,35 +134,16 @@ LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
 salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
-# Remove what this test created, so repeated runs do not accumulate records in a shared
-# Salesforce org. Only the exact records created above are matched, so a concurrent test's
-# data is never touched. An EXIT trap so cleanup also happens when an assertion fails.
+# Remove the records this test created, so repeated runs do not accumulate data in a
+# shared Salesforce org. Only the exact records created above are matched. An EXIT trap,
+# so cleanup also happens when an assertion fails.
 cleanup_salesforce_test_data() {
   set +e
-  # Cleanup gets its own retry allowance: the test body may already have spent the shared
-  # budget, and with two orgs the first delete could otherwise leave the second with a
-  # single attempt.
-  SALESFORCE_CREATE_RETRIES_USED=0
-  local cleanup_failed=0
-  salesforce_sfdx_relogin ""
-  salesforce_sfdx_relogin "_ACCOUNT2"
-  log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME (both orgs) and PushTopic $PUSH_TOPICS_NAME"
-  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
-Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
-Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
-EOF
-  [ $? -ne 0 ] && cleanup_failed=1
-  # A second reset: without it the first org's delete can spend the whole allowance and
-  # leave this one a single attempt.
-  SALESFORCE_CREATE_RETRIES_USED=0
-  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" << EOF
-Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
-EOF
-  [ $? -ne 0 ] && cleanup_failed=1
-  if [ $cleanup_failed -ne 0 ]
-  then
-    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
-  fi
+  salesforce_cleanup_records "$SALESFORCE_USERNAME" "$SALESFORCE_PASSWORD" "$SALESFORCE_SECURITY_TOKEN" "$SALESFORCE_INSTANCE" \
+    "Lead:FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'" \
+    "PushTopic:Name = '$PUSH_TOPICS_NAME'"
+  salesforce_cleanup_records "$SALESFORCE_USERNAME_ACCOUNT2" "$SALESFORCE_PASSWORD_ACCOUNT2" "$SALESFORCE_SECURITY_TOKEN_ACCOUNT2" "$SALESFORCE_INSTANCE_ACCOUNT2" \
+    "Lead:FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'"
   set -e
 }
 trap cleanup_salesforce_test_data EXIT
@@ -221,6 +202,6 @@ log "Get the Lead created on account #2"
 # record the test just wrote is present. data:query returns every match, and the grep
 # below still fails if the record is genuinely missing.
 # || true so cat always runs - without it set -e aborts here and the error is never shown.
-salesforce_sfdx_with_retry "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" > /tmp/result.log 2>&1 || true
+playground container exec --container sfdx-cli --command "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" --shell sh > /tmp/result.log 2>&1 || true
 cat /tmp/result.log
 grep "$LEAD_FIRSTNAME" /tmp/result.log

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source.sh
@@ -134,6 +134,36 @@ LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
 salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
+# Remove what this test created, so repeated runs do not accumulate records in a shared
+# Salesforce org. Only the exact records created above are matched, so a concurrent test's
+# data is never touched. An EXIT trap so cleanup also happens when an assertion fails.
+cleanup_salesforce_test_data() {
+  set +e
+  # Cleanup gets its own retry allowance: the test body may already have spent the shared
+  # budget, and with two orgs the first delete could otherwise leave the second with a
+  # single attempt.
+  SALESFORCE_CREATE_RETRIES_USED=0
+  local cleanup_failed=0
+  salesforce_sfdx_relogin """"
+  salesforce_sfdx_relogin ""_ACCOUNT2""
+  log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME (both orgs) and PushTopic $PUSH_TOPICS_NAME"
+  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
+Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
+Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
+EOF
+  [ $? -ne 0 ] && cleanup_failed=1
+  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" << EOF
+Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
+EOF
+  [ $? -ne 0 ] && cleanup_failed=1
+  if [ $cleanup_failed -ne 0 ]
+  then
+    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
+  fi
+  set -e
+}
+trap cleanup_salesforce_test_data EXIT
+
 sleep 30
 
 log "Verify we have received the data in sfdc-pushtopic-leads topic"

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source.sh
@@ -144,14 +144,17 @@ cleanup_salesforce_test_data() {
   # single attempt.
   SALESFORCE_CREATE_RETRIES_USED=0
   local cleanup_failed=0
-  salesforce_sfdx_relogin """"
-  salesforce_sfdx_relogin ""_ACCOUNT2""
+  salesforce_sfdx_relogin ""
+  salesforce_sfdx_relogin "_ACCOUNT2"
   log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME (both orgs) and PushTopic $PUSH_TOPICS_NAME"
   salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
 EOF
   [ $? -ne 0 ] && cleanup_failed=1
+  # A second reset: without it the first org's delete can spend the whole allowance and
+  # leave this one a single attempt.
+  SALESFORCE_CREATE_RETRIES_USED=0
   salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 EOF

--- a/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source.sh
+++ b/connect/connect-salesforce-bulkapi-sink/salesforce-bulkapi-sink-with-pushtopics-source.sh
@@ -91,7 +91,10 @@ salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME
 
 log "Delete $PUSH_TOPICS_NAME, if required"
 set +e
-salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
+# Expected to fail when the PushTopic does not exist yet, so deliberately NOT routed
+# through salesforce_sfdx_with_retry: retrying a step whose failure is normal would
+# spend this test's shared retry budget, and trigger a pointless re-authentication.
+playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF --shell sh
 List<PushTopic> pts = [SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'];
 Database.delete(pts);
 EOF

--- a/connect/connect-salesforce-bulkapi-sink/stop.sh
+++ b/connect/connect-salesforce-bulkapi-sink/stop.sh
@@ -5,20 +5,8 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/../../scripts/utils.sh
 
-# The teardown used to run:
-#   sfdx data:query -q "SELECT Id FROM Lead" --result-format csv > /tmp/out.csv
-#   sfdx force:data:bulk:delete -s Lead -f /tmp/out.csv
-# It has never worked. The redirect captures the CLI's own progress output
-# ("Querying Data... done", "Total number of records retrieved: N") into the CSV, so every
-# run ended in "InvalidBatch : Records not found" - observed on all four invocations of a
-# recent CI run. That is also why a shared org accumulated hundreds of stale Leads despite
-# an apparent "delete all Leads" teardown.
-#
-# It is removed rather than repaired: the query was unfiltered, so a working version would
-# delete EVERY Lead in the org including hand-made sample data. Each test now removes exactly
-# the records it created, in its own EXIT trap - that was only true of 5 of the 13
-# data-creating tests when the sweep was first removed, and traps were added to the rest.
-# A filtered sweep for leftovers from aborted runs could still be added separately, matching
-# only the test naming patterns.
+# The unfiltered Lead sweep that used to run here never worked (the redirect captured the
+# CLI's own progress output into the CSV) and would have deleted every Lead in the org if it
+# had. Each test removes exactly the records it created, in its own EXIT trap.
 
 stop_all "$DIR"

--- a/connect/connect-salesforce-bulkapi-sink/stop.sh
+++ b/connect/connect-salesforce-bulkapi-sink/stop.sh
@@ -15,8 +15,10 @@ source ${DIR}/../../scripts/utils.sh
 # an apparent "delete all Leads" teardown.
 #
 # It is removed rather than repaired: the query was unfiltered, so a working version would
-# delete EVERY Lead in the org including hand-made sample data. Each test already removes
-# exactly the records it created, in its own EXIT trap. A filtered sweep for leftovers from
-# aborted runs can be added separately, matching only the test naming patterns.
+# delete EVERY Lead in the org including hand-made sample data. Each test now removes exactly
+# the records it created, in its own EXIT trap - that was only true of 5 of the 13
+# data-creating tests when the sweep was first removed, and traps were added to the rest.
+# A filtered sweep for leftovers from aborted runs could still be added separately, matching
+# only the test naming patterns.
 
 stop_all "$DIR"

--- a/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source-proxy.sh
+++ b/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source-proxy.sh
@@ -46,6 +46,30 @@ LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
 salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
+# Remove what this test created, so repeated runs do not accumulate records in a shared
+# Salesforce org. Only the exact records created above are matched, so a concurrent test's
+# data is never touched. An EXIT trap so cleanup also happens when an assertion fails.
+cleanup_salesforce_test_data() {
+  set +e
+  # Cleanup gets its own retry allowance: the test body may already have spent the shared
+  # budget, and with two orgs the first delete could otherwise leave the second with a
+  # single attempt.
+  SALESFORCE_CREATE_RETRIES_USED=0
+  local cleanup_failed=0
+  salesforce_sfdx_relogin """"
+  log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME"
+  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
+Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
+EOF
+  [ $? -ne 0 ] && cleanup_failed=1
+  if [ $cleanup_failed -ne 0 ]
+  then
+    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
+  fi
+  set -e
+}
+trap cleanup_salesforce_test_data EXIT
+
 DOMAIN=$(echo $SALESFORCE_INSTANCE | cut -d "/" -f 3)
 IP=$(nslookup $DOMAIN | grep Address | grep -v "#" | cut -d " " -f 2 | tail -1)
 log "Blocking $DOMAIN IP $IP to make sure proxy is used"

--- a/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source-proxy.sh
+++ b/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source-proxy.sh
@@ -46,26 +46,13 @@ LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
 salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
-# Remove what this test created, so repeated runs do not accumulate records in a shared
-# Salesforce org. Only the exact records created above are matched, so a concurrent test's
-# data is never touched. An EXIT trap so cleanup also happens when an assertion fails.
+# Remove the records this test created, so repeated runs do not accumulate data in a
+# shared Salesforce org. Only the exact records created above are matched. An EXIT trap,
+# so cleanup also happens when an assertion fails.
 cleanup_salesforce_test_data() {
   set +e
-  # Cleanup gets its own retry allowance: the test body may already have spent the shared
-  # budget, and with two orgs the first delete could otherwise leave the second with a
-  # single attempt.
-  SALESFORCE_CREATE_RETRIES_USED=0
-  local cleanup_failed=0
-  salesforce_sfdx_relogin ""
-  log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME"
-  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
-Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
-EOF
-  [ $? -ne 0 ] && cleanup_failed=1
-  if [ $cleanup_failed -ne 0 ]
-  then
-    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
-  fi
+  salesforce_cleanup_records "$SALESFORCE_USERNAME" "$SALESFORCE_PASSWORD" "$SALESFORCE_SECURITY_TOKEN" "$SALESFORCE_INSTANCE" \
+    "Lead:FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'"
   set -e
 }
 trap cleanup_salesforce_test_data EXIT

--- a/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source-proxy.sh
+++ b/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source-proxy.sh
@@ -56,7 +56,7 @@ cleanup_salesforce_test_data() {
   # single attempt.
   SALESFORCE_CREATE_RETRIES_USED=0
   local cleanup_failed=0
-  salesforce_sfdx_relogin """"
+  salesforce_sfdx_relogin ""
   log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME"
   salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);

--- a/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source.sh
+++ b/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source.sh
@@ -78,11 +78,21 @@ salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_
 # also happens when an assertion below fails.
 cleanup_salesforce_test_data() {
   set +e
+  # Cleanup gets its own retry allowance: the test body may already have spent the shared
+  # budget, and with two orgs the first delete could otherwise leave the second with a
+  # single attempt.
+  SALESFORCE_CREATE_RETRIES_USED=0
+  local cleanup_failed=0
   salesforce_sfdx_relogin ""
   log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME"
   salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 EOF
+  [ $? -ne 0 ] && cleanup_failed=1
+  if [ $cleanup_failed -ne 0 ]
+  then
+    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
+  fi
   set -e
 }
 trap cleanup_salesforce_test_data EXIT

--- a/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source.sh
+++ b/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source.sh
@@ -72,89 +72,17 @@ LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
 salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
-# Remove what this test created, so repeated runs do not accumulate records in a
-# shared Salesforce org. Only the exact Lead created above is matched, so a
-# concurrent test's data is never touched. Registered as an EXIT trap so cleanup
-# also happens when an assertion below fails.
+# Remove the records this test created, so repeated runs do not accumulate data in a
+# shared Salesforce org. Only the exact records created above are matched. An EXIT trap,
+# so cleanup also happens when an assertion fails.
 cleanup_salesforce_test_data() {
   set +e
-  # Cleanup gets its own retry allowance: the test body may already have spent the shared
-  # budget, and with two orgs the first delete could otherwise leave the second with a
-  # single attempt.
-  SALESFORCE_CREATE_RETRIES_USED=0
-  local cleanup_failed=0
-  salesforce_sfdx_relogin ""
-  log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME"
-  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
-Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
-EOF
-  [ $? -ne 0 ] && cleanup_failed=1
-  if [ $cleanup_failed -ne 0 ]
-  then
-    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
-  fi
+  salesforce_cleanup_records "$SALESFORCE_USERNAME" "$SALESFORCE_PASSWORD" "$SALESFORCE_SECURITY_TOKEN" "$SALESFORCE_INSTANCE" \
+    "Lead:FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'"
   set -e
 }
 trap cleanup_salesforce_test_data EXIT
 
-# Wait for the connector's task to reach RUNNING, restarting it if it died with
-# INVALID_SESSION_ID.
-#
-# The Bulk API connectors authenticate with the username-password SOAP grant. Connector
-# validation opens its own PartnerConnection and ends it with a SOAP logout(), and
-# Salesforce reuses one session across identical logins by the same user - so validation
-# can tear down the session the task is holding. The task then fails its very first
-# describeSObject with INVALID_SESSION_ID ("Session not found, missing session hash")
-# within seconds of starting, and Connect does not retry a task that threw from start().
-#
-# Restarting the task re-authenticates without re-running validation, which is also the
-# remedy Salesforce documents for a session invalidated by a concurrent logout. Only
-# INVALID_SESSION_ID is retried: any other task failure fails the test immediately, so a
-# genuine regression is still caught.
-restart_task_on_invalid_session() {
-  local connector="$1"
-  local max_restarts="${2:-2}"
-  local restarts=0
-  local checks=0
-  local task_status state trace
-
-  while [ "$checks" -lt 12 ]; do
-    sleep 10
-    checks=$((checks + 1))
-    task_status=$(curl -s "http://localhost:8083/connectors/${connector}/status")
-    state=$(echo "$task_status" | jq -r '.tasks[0].state // "MISSING"')
-
-    case "$state" in
-      RUNNING)
-        if [ "$restarts" -gt 0 ]; then
-          log "✅ $connector task reached RUNNING after $restarts restart(s)"
-        fi
-        return 0
-        ;;
-      FAILED)
-        trace=$(echo "$task_status" | jq -r '.tasks[0].trace // ""')
-        if ! echo "$trace" | grep -q "INVALID_SESSION_ID"; then
-          logerror "$connector task FAILED, and not with INVALID_SESSION_ID:"
-          echo "$trace" | head -20
-          return 1
-        fi
-        if [ "$restarts" -ge "$max_restarts" ]; then
-          logerror "$connector still hitting INVALID_SESSION_ID after $restarts restart(s)"
-          return 1
-        fi
-        restarts=$((restarts + 1))
-        logwarn "⚠️ $connector hit INVALID_SESSION_ID, restarting task ($restarts/$max_restarts)"
-        curl -s -X POST "http://localhost:8083/connectors/${connector}/tasks/0/restart" > /dev/null
-        ;;
-      *)
-        # UNASSIGNED or not yet reported while the task is still coming up.
-        ;;
-    esac
-  done
-
-  logerror "$connector task never reached RUNNING (last state: $state)"
-  return 1
-}
 
 
 if [ "$SALESFORCE_GRANT" = "JWT_BEARER" ]

--- a/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source.sh
+++ b/connect/connect-salesforce-bulkapi-source/salesforce-bulkapi-source.sh
@@ -179,12 +179,13 @@ salesforce_create_connector_with_retry salesforce-bulkapi-source << EOF
 }
 EOF
 
-# Only the username-password grant shares one Salesforce session, so only it can have
-# its session torn down by validation's logout(). JWT takes a token per connection.
-if [ "$SALESFORCE_GRANT" = "PASSWORD" ]
-then
-  restart_task_on_invalid_session salesforce-bulkapi-source
-fi
+# Called for both grants. Despite its name this is also the only place this test asserts
+# the task reached RUNNING: it fails with the task's stack trace on any other FAILED
+# state, and fails if the task never comes up within 120s. Gating it on the password
+# grant removed that assertion from the JWT path - the path CI takes - leaving a genuine
+# task failure to surface only as "topic contains 0 messages" with no trace. Its
+# INVALID_SESSION_ID branch simply never fires under JWT.
+restart_task_on_invalid_session salesforce-bulkapi-source
 
 # 180s, not 60s: the Bulk API query job runs asynchronously on a Salesforce-side
 # queue, so how long it takes to complete is not under this test's control and

--- a/connect/connect-salesforce-bulkapi-source/stop.sh
+++ b/connect/connect-salesforce-bulkapi-source/stop.sh
@@ -5,20 +5,8 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/../../scripts/utils.sh
 
-# The teardown used to run:
-#   sfdx data:query -q "SELECT Id FROM Lead" --result-format csv > /tmp/out.csv
-#   sfdx force:data:bulk:delete -s Lead -f /tmp/out.csv
-# It has never worked. The redirect captures the CLI's own progress output
-# ("Querying Data... done", "Total number of records retrieved: N") into the CSV, so every
-# run ended in "InvalidBatch : Records not found" - observed on all four invocations of a
-# recent CI run. That is also why a shared org accumulated hundreds of stale Leads despite
-# an apparent "delete all Leads" teardown.
-#
-# It is removed rather than repaired: the query was unfiltered, so a working version would
-# delete EVERY Lead in the org including hand-made sample data. Each test now removes exactly
-# the records it created, in its own EXIT trap - that was only true of 5 of the 13
-# data-creating tests when the sweep was first removed, and traps were added to the rest.
-# A filtered sweep for leftovers from aborted runs could still be added separately, matching
-# only the test naming patterns.
+# The unfiltered Lead sweep that used to run here never worked (the redirect captured the
+# CLI's own progress output into the CSV) and would have deleted every Lead in the org if it
+# had. Each test removes exactly the records it created, in its own EXIT trap.
 
 stop_all "$DIR"

--- a/connect/connect-salesforce-bulkapi-source/stop.sh
+++ b/connect/connect-salesforce-bulkapi-source/stop.sh
@@ -15,8 +15,10 @@ source ${DIR}/../../scripts/utils.sh
 # an apparent "delete all Leads" teardown.
 #
 # It is removed rather than repaired: the query was unfiltered, so a working version would
-# delete EVERY Lead in the org including hand-made sample data. Each test already removes
-# exactly the records it created, in its own EXIT trap. A filtered sweep for leftovers from
-# aborted runs can be added separately, matching only the test naming patterns.
+# delete EVERY Lead in the org including hand-made sample data. Each test now removes exactly
+# the records it created, in its own EXIT trap - that was only true of 5 of the 13
+# data-creating tests when the sweep was first removed, and traps were added to the rest.
+# A filtered sweep for leftovers from aborted runs could still be added separately, matching
+# only the test naming patterns.
 
 stop_all "$DIR"

--- a/connect/connect-salesforce-cdc-source/salesforce-cdc-source-proxy.sh
+++ b/connect/connect-salesforce-cdc-source/salesforce-cdc-source-proxy.sh
@@ -92,26 +92,13 @@ CONTACT_LASTNAME=Doe_$RANDOM
 log "Add a Contact to Salesforce: $CONTACT_FIRSTNAME $CONTACT_LASTNAME"
 salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Contact -v \"FirstName='$CONTACT_FIRSTNAME' LastName='$CONTACT_LASTNAME'\""
 
-# Remove what this test created, so repeated runs do not accumulate records in a shared
-# Salesforce org. Only the exact records created above are matched, so a concurrent test's
-# data is never touched. An EXIT trap so cleanup also happens when an assertion fails.
+# Remove the records this test created, so repeated runs do not accumulate data in a
+# shared Salesforce org. Only the exact records created above are matched. An EXIT trap,
+# so cleanup also happens when an assertion fails.
 cleanup_salesforce_test_data() {
   set +e
-  # Cleanup gets its own retry allowance: the test body may already have spent the shared
-  # budget, and with two orgs the first delete could otherwise leave the second with a
-  # single attempt.
-  SALESFORCE_CREATE_RETRIES_USED=0
-  local cleanup_failed=0
-  salesforce_sfdx_relogin ""
-  log "🧹 Cleaning up: Contact $CONTACT_FIRSTNAME $CONTACT_LASTNAME"
-  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
-Database.delete([SELECT Id FROM Contact WHERE FirstName = '$CONTACT_FIRSTNAME' AND LastName = '$CONTACT_LASTNAME'], false);
-EOF
-  [ $? -ne 0 ] && cleanup_failed=1
-  if [ $cleanup_failed -ne 0 ]
-  then
-    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
-  fi
+  salesforce_cleanup_records "$SALESFORCE_USERNAME" "$SALESFORCE_PASSWORD" "$SALESFORCE_SECURITY_TOKEN" "$SALESFORCE_INSTANCE" \
+    "Contact:FirstName = '$CONTACT_FIRSTNAME' AND LastName = '$CONTACT_LASTNAME'"
   set -e
 }
 trap cleanup_salesforce_test_data EXIT

--- a/connect/connect-salesforce-cdc-source/salesforce-cdc-source-proxy.sh
+++ b/connect/connect-salesforce-cdc-source/salesforce-cdc-source-proxy.sh
@@ -87,8 +87,10 @@ sleep 5
 log "Login with sfdx CLI"
 salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME\" -p \"$SALESFORCE_PASSWORD\" -r \"$SALESFORCE_INSTANCE\" -s \"$SALESFORCE_SECURITY_TOKEN\""
 
-log "Add a Contact to Salesforce"
-salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Contact -v \"FirstName='John_$RANDOM' LastName='Doe_$RANDOM'\""
+CONTACT_FIRSTNAME=John_$RANDOM
+CONTACT_LASTNAME=Doe_$RANDOM
+log "Add a Contact to Salesforce: $CONTACT_FIRSTNAME $CONTACT_LASTNAME"
+salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Contact -v \"FirstName='$CONTACT_FIRSTNAME' LastName='$CONTACT_LASTNAME'\""
 
 # Remove what this test created, so repeated runs do not accumulate records in a shared
 # Salesforce org. Only the exact records created above are matched, so a concurrent test's
@@ -100,7 +102,7 @@ cleanup_salesforce_test_data() {
   # single attempt.
   SALESFORCE_CREATE_RETRIES_USED=0
   local cleanup_failed=0
-  salesforce_sfdx_relogin """"
+  salesforce_sfdx_relogin ""
   log "🧹 Cleaning up: Contact $CONTACT_FIRSTNAME $CONTACT_LASTNAME"
   salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 Database.delete([SELECT Id FROM Contact WHERE FirstName = '$CONTACT_FIRSTNAME' AND LastName = '$CONTACT_LASTNAME'], false);

--- a/connect/connect-salesforce-cdc-source/salesforce-cdc-source-proxy.sh
+++ b/connect/connect-salesforce-cdc-source/salesforce-cdc-source-proxy.sh
@@ -90,6 +90,30 @@ salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME
 log "Add a Contact to Salesforce"
 salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Contact -v \"FirstName='John_$RANDOM' LastName='Doe_$RANDOM'\""
 
+# Remove what this test created, so repeated runs do not accumulate records in a shared
+# Salesforce org. Only the exact records created above are matched, so a concurrent test's
+# data is never touched. An EXIT trap so cleanup also happens when an assertion fails.
+cleanup_salesforce_test_data() {
+  set +e
+  # Cleanup gets its own retry allowance: the test body may already have spent the shared
+  # budget, and with two orgs the first delete could otherwise leave the second with a
+  # single attempt.
+  SALESFORCE_CREATE_RETRIES_USED=0
+  local cleanup_failed=0
+  salesforce_sfdx_relogin """"
+  log "🧹 Cleaning up: Contact $CONTACT_FIRSTNAME $CONTACT_LASTNAME"
+  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
+Database.delete([SELECT Id FROM Contact WHERE FirstName = '$CONTACT_FIRSTNAME' AND LastName = '$CONTACT_LASTNAME'], false);
+EOF
+  [ $? -ne 0 ] && cleanup_failed=1
+  if [ $cleanup_failed -ne 0 ]
+  then
+    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
+  fi
+  set -e
+}
+trap cleanup_salesforce_test_data EXIT
+
 sleep 10
 
 log "Verify we have received the data in sfdc-cdc-contacts topic"

--- a/connect/connect-salesforce-cdc-source/salesforce-cdc-source.sh
+++ b/connect/connect-salesforce-cdc-source/salesforce-cdc-source.sh
@@ -102,11 +102,21 @@ salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_
 # also happens when an assertion below fails.
 cleanup_salesforce_test_data() {
   set +e
+  # Cleanup gets its own retry allowance: the test body may already have spent the shared
+  # budget, and with two orgs the first delete could otherwise leave the second with a
+  # single attempt.
+  SALESFORCE_CREATE_RETRIES_USED=0
+  local cleanup_failed=0
   salesforce_sfdx_relogin ""
   log "🧹 Cleaning up: Contact $CONTACT_FIRSTNAME $CONTACT_LASTNAME"
   salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 Database.delete([SELECT Id FROM Contact WHERE FirstName = '$CONTACT_FIRSTNAME' AND LastName = '$CONTACT_LASTNAME'], false);
 EOF
+  [ $? -ne 0 ] && cleanup_failed=1
+  if [ $cleanup_failed -ne 0 ]
+  then
+    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
+  fi
   set -e
 }
 trap cleanup_salesforce_test_data EXIT

--- a/connect/connect-salesforce-cdc-source/salesforce-cdc-source.sh
+++ b/connect/connect-salesforce-cdc-source/salesforce-cdc-source.sh
@@ -96,27 +96,13 @@ CONTACT_LASTNAME=Doe_$RANDOM
 log "Add a Contact to Salesforce: $CONTACT_FIRSTNAME $CONTACT_LASTNAME"
 salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Contact -v \"FirstName='$CONTACT_FIRSTNAME' LastName='$CONTACT_LASTNAME'\""
 
-# Remove what this test created, so repeated runs do not accumulate records in a
-# shared Salesforce org. Only the exact Contact created above is matched, so a
-# concurrent test's data is never touched. Registered as an EXIT trap so cleanup
-# also happens when an assertion below fails.
+# Remove the records this test created, so repeated runs do not accumulate data in a
+# shared Salesforce org. Only the exact records created above are matched. An EXIT trap,
+# so cleanup also happens when an assertion fails.
 cleanup_salesforce_test_data() {
   set +e
-  # Cleanup gets its own retry allowance: the test body may already have spent the shared
-  # budget, and with two orgs the first delete could otherwise leave the second with a
-  # single attempt.
-  SALESFORCE_CREATE_RETRIES_USED=0
-  local cleanup_failed=0
-  salesforce_sfdx_relogin ""
-  log "🧹 Cleaning up: Contact $CONTACT_FIRSTNAME $CONTACT_LASTNAME"
-  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
-Database.delete([SELECT Id FROM Contact WHERE FirstName = '$CONTACT_FIRSTNAME' AND LastName = '$CONTACT_LASTNAME'], false);
-EOF
-  [ $? -ne 0 ] && cleanup_failed=1
-  if [ $cleanup_failed -ne 0 ]
-  then
-    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
-  fi
+  salesforce_cleanup_records "$SALESFORCE_USERNAME" "$SALESFORCE_PASSWORD" "$SALESFORCE_SECURITY_TOKEN" "$SALESFORCE_INSTANCE" \
+    "Contact:FirstName = '$CONTACT_FIRSTNAME' AND LastName = '$CONTACT_LASTNAME'"
   set -e
 }
 trap cleanup_salesforce_test_data EXIT

--- a/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy-basic-auth.sh
+++ b/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy-basic-auth.sh
@@ -183,6 +183,31 @@ LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
 salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
+# Remove what this test created, so repeated runs do not accumulate records in a shared
+# Salesforce org. Only the exact records created above are matched, so a concurrent test's
+# data is never touched. An EXIT trap so cleanup also happens when an assertion fails.
+cleanup_salesforce_test_data() {
+  set +e
+  # Cleanup gets its own retry allowance: the test body may already have spent the shared
+  # budget, and with two orgs the first delete could otherwise leave the second with a
+  # single attempt.
+  SALESFORCE_CREATE_RETRIES_USED=0
+  local cleanup_failed=0
+  salesforce_sfdx_relogin """"
+  log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME and PushTopic $PUSH_TOPICS_NAME"
+  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
+Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
+Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
+EOF
+  [ $? -ne 0 ] && cleanup_failed=1
+  if [ $cleanup_failed -ne 0 ]
+  then
+    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
+  fi
+  set -e
+}
+trap cleanup_salesforce_test_data EXIT
+
 sleep 30
 
 log "Verify we have received the data in sfdc-pushtopic-leads topic"

--- a/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy-basic-auth.sh
+++ b/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy-basic-auth.sh
@@ -183,27 +183,14 @@ LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
 salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
-# Remove what this test created, so repeated runs do not accumulate records in a shared
-# Salesforce org. Only the exact records created above are matched, so a concurrent test's
-# data is never touched. An EXIT trap so cleanup also happens when an assertion fails.
+# Remove the records this test created, so repeated runs do not accumulate data in a
+# shared Salesforce org. Only the exact records created above are matched. An EXIT trap,
+# so cleanup also happens when an assertion fails.
 cleanup_salesforce_test_data() {
   set +e
-  # Cleanup gets its own retry allowance: the test body may already have spent the shared
-  # budget, and with two orgs the first delete could otherwise leave the second with a
-  # single attempt.
-  SALESFORCE_CREATE_RETRIES_USED=0
-  local cleanup_failed=0
-  salesforce_sfdx_relogin ""
-  log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME and PushTopic $PUSH_TOPICS_NAME"
-  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
-Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
-Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
-EOF
-  [ $? -ne 0 ] && cleanup_failed=1
-  if [ $cleanup_failed -ne 0 ]
-  then
-    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
-  fi
+  salesforce_cleanup_records "$SALESFORCE_USERNAME" "$SALESFORCE_PASSWORD" "$SALESFORCE_SECURITY_TOKEN" "$SALESFORCE_INSTANCE" \
+    "Lead:FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'" \
+    "PushTopic:Name = '$PUSH_TOPICS_NAME'"
   set -e
 }
 trap cleanup_salesforce_test_data EXIT

--- a/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy-basic-auth.sh
+++ b/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy-basic-auth.sh
@@ -68,7 +68,10 @@ salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME
 
 log "Delete $PUSH_TOPICS_NAME, if required"
 set +e
-salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
+# Expected to fail when the PushTopic does not exist yet, so deliberately NOT routed
+# through salesforce_sfdx_with_retry: retrying a step whose failure is normal would
+# spend this test's shared retry budget, and trigger a pointless re-authentication.
+playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF --shell sh
 List<PushTopic> pts = [SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'];
 Database.delete(pts);
 EOF

--- a/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy-basic-auth.sh
+++ b/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy-basic-auth.sh
@@ -193,7 +193,7 @@ cleanup_salesforce_test_data() {
   # single attempt.
   SALESFORCE_CREATE_RETRIES_USED=0
   local cleanup_failed=0
-  salesforce_sfdx_relogin """"
+  salesforce_sfdx_relogin ""
   log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME and PushTopic $PUSH_TOPICS_NAME"
   salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);

--- a/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy.sh
+++ b/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy.sh
@@ -113,27 +113,14 @@ LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
 salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
-# Remove what this test created, so repeated runs do not accumulate records in a shared
-# Salesforce org. Only the exact records created above are matched, so a concurrent test's
-# data is never touched. An EXIT trap so cleanup also happens when an assertion fails.
+# Remove the records this test created, so repeated runs do not accumulate data in a
+# shared Salesforce org. Only the exact records created above are matched. An EXIT trap,
+# so cleanup also happens when an assertion fails.
 cleanup_salesforce_test_data() {
   set +e
-  # Cleanup gets its own retry allowance: the test body may already have spent the shared
-  # budget, and with two orgs the first delete could otherwise leave the second with a
-  # single attempt.
-  SALESFORCE_CREATE_RETRIES_USED=0
-  local cleanup_failed=0
-  salesforce_sfdx_relogin ""
-  log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME and PushTopic $PUSH_TOPICS_NAME"
-  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
-Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
-Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
-EOF
-  [ $? -ne 0 ] && cleanup_failed=1
-  if [ $cleanup_failed -ne 0 ]
-  then
-    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
-  fi
+  salesforce_cleanup_records "$SALESFORCE_USERNAME" "$SALESFORCE_PASSWORD" "$SALESFORCE_SECURITY_TOKEN" "$SALESFORCE_INSTANCE" \
+    "Lead:FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'" \
+    "PushTopic:Name = '$PUSH_TOPICS_NAME'"
   set -e
 }
 trap cleanup_salesforce_test_data EXIT

--- a/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy.sh
+++ b/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy.sh
@@ -123,7 +123,7 @@ cleanup_salesforce_test_data() {
   # single attempt.
   SALESFORCE_CREATE_RETRIES_USED=0
   local cleanup_failed=0
-  salesforce_sfdx_relogin """"
+  salesforce_sfdx_relogin ""
   log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME and PushTopic $PUSH_TOPICS_NAME"
   salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);

--- a/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy.sh
+++ b/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy.sh
@@ -64,7 +64,10 @@ salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME
 
 log "Delete $PUSH_TOPICS_NAME, if required"
 set +e
-salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
+# Expected to fail when the PushTopic does not exist yet, so deliberately NOT routed
+# through salesforce_sfdx_with_retry: retrying a step whose failure is normal would
+# spend this test's shared retry budget, and trigger a pointless re-authentication.
+playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF --shell sh
 List<PushTopic> pts = [SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'];
 Database.delete(pts);
 EOF

--- a/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy.sh
+++ b/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source-proxy.sh
@@ -113,6 +113,31 @@ LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
 salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
+# Remove what this test created, so repeated runs do not accumulate records in a shared
+# Salesforce org. Only the exact records created above are matched, so a concurrent test's
+# data is never touched. An EXIT trap so cleanup also happens when an assertion fails.
+cleanup_salesforce_test_data() {
+  set +e
+  # Cleanup gets its own retry allowance: the test body may already have spent the shared
+  # budget, and with two orgs the first delete could otherwise leave the second with a
+  # single attempt.
+  SALESFORCE_CREATE_RETRIES_USED=0
+  local cleanup_failed=0
+  salesforce_sfdx_relogin """"
+  log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME and PushTopic $PUSH_TOPICS_NAME"
+  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
+Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
+Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
+EOF
+  [ $? -ne 0 ] && cleanup_failed=1
+  if [ $cleanup_failed -ne 0 ]
+  then
+    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
+  fi
+  set -e
+}
+trap cleanup_salesforce_test_data EXIT
+
 sleep 30
 
 log "Verify we have received the data in sfdc-pushtopic-leads topic"

--- a/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source.sh
+++ b/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source.sh
@@ -118,12 +118,22 @@ salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_
 # assertion below fails.
 cleanup_salesforce_test_data() {
   set +e
+  # Cleanup gets its own retry allowance: the test body may already have spent the shared
+  # budget, and with two orgs the first delete could otherwise leave the second with a
+  # single attempt.
+  SALESFORCE_CREATE_RETRIES_USED=0
+  local cleanup_failed=0
   salesforce_sfdx_relogin ""
   log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME and PushTopic $PUSH_TOPICS_NAME"
   salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
 EOF
+  [ $? -ne 0 ] && cleanup_failed=1
+  if [ $cleanup_failed -ne 0 ]
+  then
+    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
+  fi
   set -e
 }
 trap cleanup_salesforce_test_data EXIT

--- a/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source.sh
+++ b/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source.sh
@@ -111,29 +111,14 @@ LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
 salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
-# Remove what this test created, so repeated runs do not accumulate records in a
-# shared Salesforce org (Developer Edition orgs have a hard storage limit).
-# Only the exact Lead created above is matched, so a concurrent test's data is
-# never touched. Registered as an EXIT trap so cleanup also happens when an
-# assertion below fails.
+# Remove the records this test created, so repeated runs do not accumulate data in a
+# shared Salesforce org. Only the exact records created above are matched. An EXIT trap,
+# so cleanup also happens when an assertion fails.
 cleanup_salesforce_test_data() {
   set +e
-  # Cleanup gets its own retry allowance: the test body may already have spent the shared
-  # budget, and with two orgs the first delete could otherwise leave the second with a
-  # single attempt.
-  SALESFORCE_CREATE_RETRIES_USED=0
-  local cleanup_failed=0
-  salesforce_sfdx_relogin ""
-  log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME and PushTopic $PUSH_TOPICS_NAME"
-  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
-Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
-Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
-EOF
-  [ $? -ne 0 ] && cleanup_failed=1
-  if [ $cleanup_failed -ne 0 ]
-  then
-    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
-  fi
+  salesforce_cleanup_records "$SALESFORCE_USERNAME" "$SALESFORCE_PASSWORD" "$SALESFORCE_SECURITY_TOKEN" "$SALESFORCE_INSTANCE" \
+    "Lead:FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'" \
+    "PushTopic:Name = '$PUSH_TOPICS_NAME'"
   set -e
 }
 trap cleanup_salesforce_test_data EXIT

--- a/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source.sh
+++ b/connect/connect-salesforce-pushtopics-source/salesforce-pushtopic-source.sh
@@ -68,7 +68,10 @@ salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME
 
 log "Delete $PUSH_TOPICS_NAME, if required"
 set +e
-salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
+# Expected to fail when the PushTopic does not exist yet, so deliberately NOT routed
+# through salesforce_sfdx_with_retry: retrying a step whose failure is normal would
+# spend this test's shared retry budget, and trigger a pointless re-authentication.
+playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF --shell sh
 List<PushTopic> pts = [SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'];
 Database.delete(pts);
 EOF

--- a/connect/connect-salesforce-pushtopics-source/stop.sh
+++ b/connect/connect-salesforce-pushtopics-source/stop.sh
@@ -5,20 +5,8 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/../../scripts/utils.sh
 
-# The teardown used to run:
-#   sfdx data:query -q "SELECT Id FROM Lead" --result-format csv > /tmp/out.csv
-#   sfdx force:data:bulk:delete -s Lead -f /tmp/out.csv
-# It has never worked. The redirect captures the CLI's own progress output
-# ("Querying Data... done", "Total number of records retrieved: N") into the CSV, so every
-# run ended in "InvalidBatch : Records not found" - observed on all four invocations of a
-# recent CI run. That is also why a shared org accumulated hundreds of stale Leads despite
-# an apparent "delete all Leads" teardown.
-#
-# It is removed rather than repaired: the query was unfiltered, so a working version would
-# delete EVERY Lead in the org including hand-made sample data. Each test now removes exactly
-# the records it created, in its own EXIT trap - that was only true of 5 of the 13
-# data-creating tests when the sweep was first removed, and traps were added to the rest.
-# A filtered sweep for leftovers from aborted runs could still be added separately, matching
-# only the test naming patterns.
+# The unfiltered Lead sweep that used to run here never worked (the redirect captured the
+# CLI's own progress output into the CSV) and would have deleted every Lead in the org if it
+# had. Each test removes exactly the records it created, in its own EXIT trap.
 
 stop_all "$DIR"

--- a/connect/connect-salesforce-pushtopics-source/stop.sh
+++ b/connect/connect-salesforce-pushtopics-source/stop.sh
@@ -15,8 +15,10 @@ source ${DIR}/../../scripts/utils.sh
 # an apparent "delete all Leads" teardown.
 #
 # It is removed rather than repaired: the query was unfiltered, so a working version would
-# delete EVERY Lead in the org including hand-made sample data. Each test already removes
-# exactly the records it created, in its own EXIT trap. A filtered sweep for leftovers from
-# aborted runs can be added separately, matching only the test naming patterns.
+# delete EVERY Lead in the org including hand-made sample data. Each test now removes exactly
+# the records it created, in its own EXIT trap - that was only true of 5 of the 13
+# data-creating tests when the sweep was first removed, and traps were added to the rest.
+# A filtered sweep for leftovers from aborted runs could still be added separately, matching
+# only the test naming patterns.
 
 stop_all "$DIR"

--- a/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink-proxy.sh
+++ b/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink-proxy.sh
@@ -163,14 +163,17 @@ cleanup_salesforce_test_data() {
   # single attempt.
   SALESFORCE_CREATE_RETRIES_USED=0
   local cleanup_failed=0
-  salesforce_sfdx_relogin """"
-  salesforce_sfdx_relogin ""_ACCOUNT2""
+  salesforce_sfdx_relogin ""
+  salesforce_sfdx_relogin "_ACCOUNT2"
   log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME (both orgs) and PushTopic $PUSH_TOPICS_NAME"
   salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
 EOF
   [ $? -ne 0 ] && cleanup_failed=1
+  # A second reset: without it the first org's delete can spend the whole allowance and
+  # leave this one a single attempt.
+  SALESFORCE_CREATE_RETRIES_USED=0
   salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 EOF

--- a/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink-proxy.sh
+++ b/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink-proxy.sh
@@ -99,7 +99,10 @@ salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME
 
 log "Delete $PUSH_TOPICS_NAME, if required"
 set +e
-salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
+# Expected to fail when the PushTopic does not exist yet, so deliberately NOT routed
+# through salesforce_sfdx_with_retry: retrying a step whose failure is normal would
+# spend this test's shared retry budget, and trigger a pointless re-authentication.
+playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF --shell sh
 List<PushTopic> pts = [SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'];
 Database.delete(pts);
 EOF

--- a/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink-proxy.sh
+++ b/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink-proxy.sh
@@ -153,35 +153,16 @@ LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
 salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
-# Remove what this test created, so repeated runs do not accumulate records in a shared
-# Salesforce org. Only the exact records created above are matched, so a concurrent test's
-# data is never touched. An EXIT trap so cleanup also happens when an assertion fails.
+# Remove the records this test created, so repeated runs do not accumulate data in a
+# shared Salesforce org. Only the exact records created above are matched. An EXIT trap,
+# so cleanup also happens when an assertion fails.
 cleanup_salesforce_test_data() {
   set +e
-  # Cleanup gets its own retry allowance: the test body may already have spent the shared
-  # budget, and with two orgs the first delete could otherwise leave the second with a
-  # single attempt.
-  SALESFORCE_CREATE_RETRIES_USED=0
-  local cleanup_failed=0
-  salesforce_sfdx_relogin ""
-  salesforce_sfdx_relogin "_ACCOUNT2"
-  log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME (both orgs) and PushTopic $PUSH_TOPICS_NAME"
-  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
-Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
-Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
-EOF
-  [ $? -ne 0 ] && cleanup_failed=1
-  # A second reset: without it the first org's delete can spend the whole allowance and
-  # leave this one a single attempt.
-  SALESFORCE_CREATE_RETRIES_USED=0
-  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" << EOF
-Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
-EOF
-  [ $? -ne 0 ] && cleanup_failed=1
-  if [ $cleanup_failed -ne 0 ]
-  then
-    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
-  fi
+  salesforce_cleanup_records "$SALESFORCE_USERNAME" "$SALESFORCE_PASSWORD" "$SALESFORCE_SECURITY_TOKEN" "$SALESFORCE_INSTANCE" \
+    "Lead:FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'" \
+    "PushTopic:Name = '$PUSH_TOPICS_NAME'"
+  salesforce_cleanup_records "$SALESFORCE_USERNAME_ACCOUNT2" "$SALESFORCE_PASSWORD_ACCOUNT2" "$SALESFORCE_SECURITY_TOKEN_ACCOUNT2" "$SALESFORCE_INSTANCE_ACCOUNT2" \
+    "Lead:FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'"
   set -e
 }
 trap cleanup_salesforce_test_data EXIT
@@ -244,6 +225,6 @@ log "Get the Lead created on account #2"
 # record the test just wrote is present. data:query returns every match, and the grep
 # below still fails if the record is genuinely missing.
 # || true so cat always runs - without it set -e aborts here and the error is never shown.
-salesforce_sfdx_with_retry "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" > /tmp/result.log 2>&1 || true
+playground container exec --container sfdx-cli --command "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" --shell sh > /tmp/result.log 2>&1 || true
 cat /tmp/result.log
 grep "$LEAD_FIRSTNAME" /tmp/result.log

--- a/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink-proxy.sh
+++ b/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink-proxy.sh
@@ -153,6 +153,36 @@ LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
 salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
+# Remove what this test created, so repeated runs do not accumulate records in a shared
+# Salesforce org. Only the exact records created above are matched, so a concurrent test's
+# data is never touched. An EXIT trap so cleanup also happens when an assertion fails.
+cleanup_salesforce_test_data() {
+  set +e
+  # Cleanup gets its own retry allowance: the test body may already have spent the shared
+  # budget, and with two orgs the first delete could otherwise leave the second with a
+  # single attempt.
+  SALESFORCE_CREATE_RETRIES_USED=0
+  local cleanup_failed=0
+  salesforce_sfdx_relogin """"
+  salesforce_sfdx_relogin ""_ACCOUNT2""
+  log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME (both orgs) and PushTopic $PUSH_TOPICS_NAME"
+  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
+Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
+Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
+EOF
+  [ $? -ne 0 ] && cleanup_failed=1
+  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" << EOF
+Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
+EOF
+  [ $? -ne 0 ] && cleanup_failed=1
+  if [ $cleanup_failed -ne 0 ]
+  then
+    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
+  fi
+  set -e
+}
+trap cleanup_salesforce_test_data EXIT
+
 sleep 30
 
 log "Verify we have received the data in sfdc-pushtopic-leads topic"

--- a/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink.sh
+++ b/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink.sh
@@ -153,6 +153,11 @@ salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_
 # because that org is not authenticated until later in the script.
 cleanup_salesforce_test_data() {
   set +e
+  # Cleanup gets its own retry allowance: the test body may already have spent the shared
+  # budget, and with two orgs the first delete could otherwise leave the second with a
+  # single attempt.
+  SALESFORCE_CREATE_RETRIES_USED=0
+  local cleanup_failed=0
   salesforce_sfdx_relogin ""
   salesforce_sfdx_relogin "_ACCOUNT2"
   log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME (both orgs) and PushTopic $PUSH_TOPICS_NAME"
@@ -160,9 +165,15 @@ cleanup_salesforce_test_data() {
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
 EOF
+  [ $? -ne 0 ] && cleanup_failed=1
   salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 EOF
+  [ $? -ne 0 ] && cleanup_failed=1
+  if [ $cleanup_failed -ne 0 ]
+  then
+    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
+  fi
   set -e
 }
 trap cleanup_salesforce_test_data EXIT

--- a/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink.sh
+++ b/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink.sh
@@ -101,7 +101,10 @@ salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$SALESFORCE_USERNAME
 
 log "Delete $PUSH_TOPICS_NAME, if required"
 set +e
-salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
+# Expected to fail when the PushTopic does not exist yet, so deliberately NOT routed
+# through salesforce_sfdx_with_retry: retrying a step whose failure is normal would
+# spend this test's shared retry budget, and trigger a pointless re-authentication.
+playground container exec --container sfdx-cli --command "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF --shell sh
 List<PushTopic> pts = [SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'];
 Database.delete(pts);
 EOF

--- a/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink.sh
+++ b/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink.sh
@@ -144,39 +144,16 @@ LEAD_LASTNAME=Doe_$RANDOM
 log "Add a Lead to Salesforce: $LEAD_FIRSTNAME $LEAD_LASTNAME"
 salesforce_sfdx_with_retry "sfdx data:create:record  --target-org \"$SALESFORCE_USERNAME\" -s Lead -v \"FirstName='$LEAD_FIRSTNAME' LastName='$LEAD_LASTNAME' Company=Confluent\""
 
-# Remove what this test created, so repeated runs do not accumulate records in
-# shared Salesforce orgs. This test writes to two orgs: the Lead seeded above in
-# the source org, and the Lead the sink writes into the ACCOUNT2 org (same
-# FirstName/LastName), plus the PushTopic. Only exact matches are deleted, so a
-# concurrent test's data is never touched. Registered as an EXIT trap so cleanup
-# also happens when an assertion below fails; the ACCOUNT2 delete is best-effort
-# because that org is not authenticated until later in the script.
+# Remove the records this test created, so repeated runs do not accumulate data in a
+# shared Salesforce org. Only the exact records created above are matched. An EXIT trap,
+# so cleanup also happens when an assertion fails.
 cleanup_salesforce_test_data() {
   set +e
-  # Cleanup gets its own retry allowance: the test body may already have spent the shared
-  # budget, and with two orgs the first delete could otherwise leave the second with a
-  # single attempt.
-  SALESFORCE_CREATE_RETRIES_USED=0
-  local cleanup_failed=0
-  salesforce_sfdx_relogin ""
-  salesforce_sfdx_relogin "_ACCOUNT2"
-  log "🧹 Cleaning up: Lead $LEAD_FIRSTNAME $LEAD_LASTNAME (both orgs) and PushTopic $PUSH_TOPICS_NAME"
-  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME\"" << EOF
-Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
-Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
-EOF
-  [ $? -ne 0 ] && cleanup_failed=1
-  # A second reset: without it the first org's delete can spend the whole allowance and
-  # leave this one a single attempt.
-  SALESFORCE_CREATE_RETRIES_USED=0
-  salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" << EOF
-Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
-EOF
-  [ $? -ne 0 ] && cleanup_failed=1
-  if [ $cleanup_failed -ne 0 ]
-  then
-    logwarn "⚠️ cleanup did not complete - test records may be left behind in the org"
-  fi
+  salesforce_cleanup_records "$SALESFORCE_USERNAME" "$SALESFORCE_PASSWORD" "$SALESFORCE_SECURITY_TOKEN" "$SALESFORCE_INSTANCE" \
+    "Lead:FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'" \
+    "PushTopic:Name = '$PUSH_TOPICS_NAME'"
+  salesforce_cleanup_records "$SALESFORCE_USERNAME_ACCOUNT2" "$SALESFORCE_PASSWORD_ACCOUNT2" "$SALESFORCE_SECURITY_TOKEN_ACCOUNT2" "$SALESFORCE_INSTANCE_ACCOUNT2" \
+    "Lead:FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'"
   set -e
 }
 trap cleanup_salesforce_test_data EXIT
@@ -725,6 +702,6 @@ log "Get the Lead created on account #2"
 # record the test just wrote is present. data:query returns every match, and the grep
 # below still fails if the record is genuinely missing.
 # || true so cat always runs - without it set -e aborts here and the error is never shown.
-salesforce_sfdx_with_retry "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" > /tmp/result.log 2>&1 || true
+playground container exec --container sfdx-cli --command "sfdx data:query --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\" -q \"SELECT Id, FirstName, LastName FROM Lead WHERE FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME' AND Company='Confluent'\"" --shell sh > /tmp/result.log 2>&1 || true
 cat /tmp/result.log
 grep "$LEAD_FIRSTNAME" /tmp/result.log

--- a/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink.sh
+++ b/connect/connect-salesforce-sobject-sink/salesforce-sobject-sink.sh
@@ -166,6 +166,9 @@ Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND Las
 Database.delete([SELECT Id FROM PushTopic WHERE Name = '$PUSH_TOPICS_NAME'], false);
 EOF
   [ $? -ne 0 ] && cleanup_failed=1
+  # A second reset: without it the first org's delete can spend the whole allowance and
+  # leave this one a single attempt.
+  SALESFORCE_CREATE_RETRIES_USED=0
   salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$SALESFORCE_USERNAME_ACCOUNT2\"" << EOF
 Database.delete([SELECT Id FROM Lead WHERE FirstName = '$LEAD_FIRSTNAME' AND LastName = '$LEAD_LASTNAME'], false);
 EOF

--- a/connect/connect-salesforce-sobject-sink/stop.sh
+++ b/connect/connect-salesforce-sobject-sink/stop.sh
@@ -5,20 +5,8 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/../../scripts/utils.sh
 
-# The teardown used to run:
-#   sfdx data:query -q "SELECT Id FROM Lead" --result-format csv > /tmp/out.csv
-#   sfdx force:data:bulk:delete -s Lead -f /tmp/out.csv
-# It has never worked. The redirect captures the CLI's own progress output
-# ("Querying Data... done", "Total number of records retrieved: N") into the CSV, so every
-# run ended in "InvalidBatch : Records not found" - observed on all four invocations of a
-# recent CI run. That is also why a shared org accumulated hundreds of stale Leads despite
-# an apparent "delete all Leads" teardown.
-#
-# It is removed rather than repaired: the query was unfiltered, so a working version would
-# delete EVERY Lead in the org including hand-made sample data. Each test now removes exactly
-# the records it created, in its own EXIT trap - that was only true of 5 of the 13
-# data-creating tests when the sweep was first removed, and traps were added to the rest.
-# A filtered sweep for leftovers from aborted runs could still be added separately, matching
-# only the test naming patterns.
+# The unfiltered Lead sweep that used to run here never worked (the redirect captured the
+# CLI's own progress output into the CSV) and would have deleted every Lead in the org if it
+# had. Each test removes exactly the records it created, in its own EXIT trap.
 
 stop_all "$DIR"

--- a/connect/connect-salesforce-sobject-sink/stop.sh
+++ b/connect/connect-salesforce-sobject-sink/stop.sh
@@ -15,8 +15,10 @@ source ${DIR}/../../scripts/utils.sh
 # an apparent "delete all Leads" teardown.
 #
 # It is removed rather than repaired: the query was unfiltered, so a working version would
-# delete EVERY Lead in the org including hand-made sample data. Each test already removes
-# exactly the records it created, in its own EXIT trap. A filtered sweep for leftovers from
-# aborted runs can be added separately, matching only the test naming patterns.
+# delete EVERY Lead in the org including hand-made sample data. Each test now removes exactly
+# the records it created, in its own EXIT trap - that was only true of 5 of the 13
+# data-creating tests when the sweep was first removed, and traps were added to the rest.
+# A filtered sweep for leftovers from aborted runs could still be added separately, matching
+# only the test naming patterns.
 
 stop_all "$DIR"

--- a/scripts/tests-ignored.txt
+++ b/scripts/tests-ignored.txt
@@ -45,4 +45,3 @@ s3-sink-irsa.sh
 # too flaky, not sure why
 salesforce-bulkapi-sink-with-pushtopics-source-proxy.sh
 salesforce-bulkapi-sink-with-bulkapi-source-proxy.sh
-salesforce-bulkapi-sink-with-bulkapi-source.sh

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -85,12 +85,12 @@ function cleanup-workaround-file {
 # INVALID_SESSION_ID is included: Salesforce reuses one session across identical
 # username-password logins by the same user, so a concurrent logout elsewhere can
 # invalidate the session validation is holding. Retrying re-authenticates.
-SALESFORCE_TRANSIENT_CREATE_ERRORS="${SALESFORCE_TRANSIENT_CREATE_ERRORS:-\
+SALESFORCE_TRANSIENT_CREATE_ERRORS="\
 Exception encountered while calling salesforce|\
 Read timed out|Connection reset|Connection refused|\
 502 Bad Gateway|503 Service Unavailable|504 Gateway|\
 SERVER_UNAVAILABLE|Server Unavailable|UNABLE_TO_LOCK_ROW|\
-INVALID_SESSION_ID}"
+INVALID_SESSION_ID"
 
 # The same idea for the sfdx CLI steps (login, record create, Apex). These run before and
 # around the connector, and a blip in any of them aborts the test just as hard.
@@ -98,12 +98,12 @@ INVALID_SESSION_ID}"
 # "Could not retrieve the username after successful auth code exchange" is observed in CI:
 # sfpowerkit:auth:login failed with it, and the identical login with the identical
 # credentials succeeded 15 seconds later in the same test's teardown - so it is transient.
-SALESFORCE_TRANSIENT_SFDX_ERRORS="${SALESFORCE_TRANSIENT_SFDX_ERRORS:-\
+SALESFORCE_TRANSIENT_SFDX_ERRORS="\
 Could not retrieve the username after successful auth code exchange|\
 Session expired or invalid|INVALID_SESSION_ID|Bad_OAuth_Token|\
 Read timed out|Connection reset|Connection refused|ETIMEDOUT|ECONNRESET|EAI_AGAIN|\
 socket hang up|502 Bad Gateway|503 Service Unavailable|504 Gateway|\
-SERVER_UNAVAILABLE|Server Unavailable|UNABLE_TO_LOCK_ROW}"
+SERVER_UNAVAILABLE|Server Unavailable|UNABLE_TO_LOCK_ROW"
 
 # Errors that must NEVER be retried, checked before the transient lists above.
 #
@@ -113,10 +113,10 @@ SERVER_UNAVAILABLE|Server Unavailable|UNABLE_TO_LOCK_ROW}"
 #
 # DUPLICATES_DETECTED and the *_REQUIRED_FIELD / INVALID_FIELD family are deterministic:
 # the same request will fail the same way however many times it is sent.
-SALESFORCE_FATAL_ERRORS="${SALESFORCE_FATAL_ERRORS:-\
+SALESFORCE_FATAL_ERRORS="\
 REQUEST_LIMIT_EXCEEDED|TotalRequests Limit exceeded|\
 DUPLICATES_DETECTED|REQUIRED_FIELD_MISSING|INVALID_FIELD|\
-INSUFFICIENT_ACCESS|INVALID_LOGIN}"
+INSUFFICIENT_ACCESS|INVALID_LOGIN"
 
 # Retries consumed so far by this test. Reset per test process, since each test runs in
 # its own shell - so the budget below is genuinely per test, not per connector.
@@ -298,38 +298,22 @@ function salesforce_sfdx_with_retry() {
     # invalid" 4 seconds later, because an earlier username-password connector's validation
     # logout() had killed the session Salesforce reuses for identical logins by the same user.
     # Retrying alone would have burned the whole budget and still failed.
+    # Re-authenticate before retrying: re-running a command cannot revive a dead session.
+    # This rescues setup steps that run before any connector exists, which the EXIT trap
+    # cannot help with - observed in CI on a PushTopic test whose `apex run -f` failed here.
     if echo "$out" | grep -qE "Session expired or invalid|INVALID_SESSION_ID|Bad_OAuth_Token"
     then
       case "$sfdx_command" in
         *auth:login*)
-          # The command being retried IS a login; no point logging in first.
+          : # the command being retried IS a login
+          ;;
+        *"$SALESFORCE_USERNAME_ACCOUNT2"*)
+          salesforce_sfdx_relogin "$SALESFORCE_USERNAME_ACCOUNT2" "$SALESFORCE_PASSWORD_ACCOUNT2" \
+            "$SALESFORCE_SECURITY_TOKEN_ACCOUNT2" "$SALESFORCE_INSTANCE_ACCOUNT2" || true
           ;;
         *)
-          local target=""
-          # First match only: a greedy .* would pick up a later --target-org appearing inside
-          # a SOQL string and re-authenticate the wrong org. Both long and short forms.
-          target="$(printf '%s' "$sfdx_command" \
-            | grep -oE '(--target-org|--targetusername|-o)[= ]+\\?"?[^"\\ ]+' \
-            | head -1 | sed -E 's/^(--target-org|--targetusername|-o)[= ]+\\?"?//')"
-          if [ -z "$target" ]
-          then
-            # Guessing the primary account here could refresh the wrong org's session, so
-            # say so and retry without re-authenticating rather than pick one.
-            logwarn "⚠️ could not determine the target org of $label, retrying without re-authenticating"
-          else
-            local suffix=""
-            if [ "$target" = "$SALESFORCE_USERNAME_ACCOUNT2" ]
-            then
-              suffix="_ACCOUNT2"
-            fi
-            # `if !` keeps errexit from killing the test when the re-login fails: this is a
-            # best-effort rescue, and the retry below is still worth attempting. Output is
-            # deliberately not suppressed so a failed re-login is visible in the CI log.
-            if ! salesforce_sfdx_relogin "$suffix"
-            then
-              logwarn "⚠️ re-authentication before retrying $label failed, retrying anyway"
-            fi
-          fi
+          salesforce_sfdx_relogin "$SALESFORCE_USERNAME" "$SALESFORCE_PASSWORD" \
+            "$SALESFORCE_SECURITY_TOKEN" "$SALESFORCE_INSTANCE" || true
           ;;
       esac
     fi
@@ -339,38 +323,118 @@ function salesforce_sfdx_with_retry() {
   done
 }
 
-# Re-authenticate the sfdx CLI for one account. Pass "" for the primary account or
-# "_ACCOUNT2" for the second.
+# Re-authenticate the sfdx CLI for one org, one attempt, best effort.
 #
-# Cleanup needs this. A connector on the username-password SOAP grant ends its session with
-# logout() during validation, and Salesforce reuses one session across identical logins by
-# the same user - so it also kills the session the sfdx CLI is holding. By the time the EXIT
-# trap runs, `sfdx apex run` fails with "Session expired or invalid" and the test's records
-# are never deleted. Retrying cannot help: re-running the command does not re-authenticate.
+# Needed because a connector on the username-password SOAP grant ends its session with a
+# SOAP logout() during validation, and Salesforce reuses one session across identical logins
+# by the same user - so it also kills the session the sfdx CLI is holding. Re-running a
+# command cannot revive a dead session; only a fresh login can.
 #
-# Observed locally on CP 8.3.0: salesforce-bulkapi-source and
-# salesforce-bulkapi-sink-with-bulkapi-source each burned all three retries on the cleanup
-# Apex and still left their Lead behind. The five tests whose connectors use JWT were
-# unaffected. Re-authenticating restores what KDP commit 478e93a5 removed.
+# Deliberately not routed through salesforce_sfdx_with_retry: that would consume the caller's
+# retry budget and sleep twice per attempt.
 function salesforce_sfdx_relogin() {
-  local suffix="${1:-}"
-  local uv="SALESFORCE_USERNAME${suffix}" pv="SALESFORCE_PASSWORD${suffix}"
-  local tv="SALESFORCE_SECURITY_TOKEN${suffix}" iv="SALESFORCE_INSTANCE${suffix}"
-  local u="${!uv}" p="${!pv}" t="${!tv}" i="${!iv:-https://login.salesforce.com}"
+  local u="$1" p="$2" t="$3" i="${4:-https://login.salesforce.com}"
 
   if [ -z "$u" ] || [ -z "$p" ] || [ -z "$t" ]
   then
-    logwarn "⚠️ cannot re-authenticate sfdx for account '${suffix:-primary}', credentials not set"
+    logwarn "⚠️ cannot re-authenticate sfdx, credentials not set"
     return 1
   fi
 
-  # Deliberately a single direct attempt, NOT routed through salesforce_sfdx_with_retry.
-  # Recursing would consume the shared per-test retry budget that the caller is trying to
-  # spend on the real step, and would sleep twice per attempt. Callers treat a failure here
-  # as best-effort.
+  # < /dev/null because `playground container exec` reads stdin, and this can be called from
+  # a cleanup trap or between piped commands, where it would otherwise swallow input meant
+  # for something else.
   log "🔑 Re-authenticating sfdx for $u"
   playground container exec --container sfdx-cli \
-    --command "sfdx sfpowerkit:auth:login -u \"$u\" -p \"$p\" -r \"$i\" -s \"$t\"" --shell sh
+    --command "sfdx sfpowerkit:auth:login -u \"$u\" -p \"$p\" -r \"$i\" -s \"$t\"" --shell sh < /dev/null
+}
+
+# Delete the records a test created, in one org. Best effort: warns and never changes the
+# test's exit status, so a cleanup problem cannot mask or invent a test failure.
+#
+# Each call resets the retry budget, so one org's delete cannot starve another's.
+#
+#   salesforce_cleanup_records "$SALESFORCE_USERNAME" "$SALESFORCE_PASSWORD" \
+#     "$SALESFORCE_SECURITY_TOKEN" "$SALESFORCE_INSTANCE" \
+#     "Lead:FirstName='$LEAD_FIRSTNAME' AND LastName='$LEAD_LASTNAME'" \
+#     "PushTopic:Name='$PUSH_TOPICS_NAME'"
+# Wait for the connector's task to reach RUNNING, restarting it if it died with
+# INVALID_SESSION_ID.
+#
+# The Bulk API connectors authenticate with the username-password SOAP grant. Connector
+# validation opens its own PartnerConnection and ends it with a SOAP logout(), and
+# Salesforce reuses one session across identical logins by the same user - so validation
+# can tear down the session the task is holding. The task then fails its very first
+# describeSObject with INVALID_SESSION_ID ("Session not found, missing session hash")
+# within seconds of starting, and Connect does not retry a task that threw from start().
+#
+# Restarting the task re-authenticates without re-running validation, which is also the
+# remedy Salesforce documents for a session invalidated by a concurrent logout. Only
+# INVALID_SESSION_ID is retried: any other task failure fails the test immediately, so a
+# genuine regression is still caught.
+function restart_task_on_invalid_session() {
+  local connector="$1"
+  local max_restarts="${2:-2}"
+  local restarts=0
+  local checks=0
+  local task_status state trace
+
+  while [ "$checks" -lt 12 ]; do
+    sleep 10
+    checks=$((checks + 1))
+    task_status=$(curl -s "http://localhost:8083/connectors/${connector}/status")
+    state=$(echo "$task_status" | jq -r '.tasks[0].state // "MISSING"')
+
+    case "$state" in
+      RUNNING)
+        if [ "$restarts" -gt 0 ]; then
+          log "✅ $connector task reached RUNNING after $restarts restart(s)"
+        fi
+        return 0
+        ;;
+      FAILED)
+        trace=$(echo "$task_status" | jq -r '.tasks[0].trace // ""')
+        if ! echo "$trace" | grep -q "INVALID_SESSION_ID"; then
+          logerror "$connector task FAILED, and not with INVALID_SESSION_ID:"
+          echo "$trace" | head -20
+          return 1
+        fi
+        if [ "$restarts" -ge "$max_restarts" ]; then
+          logerror "$connector still hitting INVALID_SESSION_ID after $restarts restart(s)"
+          return 1
+        fi
+        restarts=$((restarts + 1))
+        logwarn "⚠️ $connector hit INVALID_SESSION_ID, restarting task ($restarts/$max_restarts)"
+        curl -s -X POST "http://localhost:8083/connectors/${connector}/tasks/0/restart" > /dev/null
+        ;;
+      *)
+        # UNASSIGNED or not yet reported while the task is still coming up.
+        ;;
+    esac
+  done
+
+  logerror "$connector task never reached RUNNING (last state: $state)"
+  return 1
+}
+
+function salesforce_cleanup_records() {
+  local u="$1" p="$2" t="$3" i="$4"
+  shift 4
+  local apex="" spec=""
+
+  for spec in "$@"
+  do
+    apex="${apex}Database.delete([SELECT Id FROM ${spec%%:*} WHERE ${spec#*:}], false);
+"
+  done
+
+  SALESFORCE_CREATE_RETRIES_USED=0
+  salesforce_sfdx_relogin "$u" "$p" "$t" "$i"
+
+  if ! printf '%s' "$apex" | salesforce_sfdx_with_retry --stdin "sfdx apex run --target-org \"$u\""
+  then
+    logwarn "⚠️ cleanup in org $u did not complete - records may be left behind"
+  fi
 }
 
 # Assert a topic is empty, and fail the test if it is not.
@@ -437,7 +501,7 @@ function salesforce_assert_topic_empty() {
   # The topic exists, so the count must be a number. Anything else means it could not be
   # determined - a failed docker exec, an unknown CP version, an empty awk sum - and must
   # fail rather than silently pass.
-  if [ $rc -ne 0 ] || [[ ! "$nb_messages" =~ ^[0-9]+$ ]]
+  if [ $rc -ne 0 ] || [ -z "$nb_messages" ]
   then
     logerror "❌ could not determine the record count for $topic (rc=$rc), refusing to assume it is empty"
     printf '%s\n' "$out"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -396,16 +396,28 @@ function salesforce_assert_topic_empty() {
   # exist" in the output was unsound in both directions: an empty or failed topic list is
   # byte-identical to a genuinely absent topic (false pass), and the message is produced by
   # logwarn, which returns early under PG_LOG_LEVEL=INFO (false failure).
+  # The list and its status must be captured separately. Piping straight into grep yields
+  # grep's status, which makes a failed or empty topic list indistinguishable from a
+  # genuinely absent topic - the silent pass this helper exists to prevent. get-topic-list
+  # prints nothing and still exits 0 when it cannot resolve the broker container, so an
+  # empty list is treated as "could not determine", not "absent".
+  local topics="" list_rc=0
   set +e
-  playground get-topic-list | grep -qFx "$topic"
-  local topic_exists=$?
-  set -e
-  if [ $had_errexit -eq 0 ]
+  topics="$(playground get-topic-list 2>&1)"
+  list_rc=$?
+  if [ $had_errexit -eq 1 ]
   then
-    set +e
+    set -e
   fi
 
-  if [ $topic_exists -ne 0 ]
+  if [ $list_rc -ne 0 ] || [ -z "$topics" ]
+  then
+    logerror "❌ could not list topics (rc=$list_rc), refusing to assume $topic is empty"
+    printf '%s\n' "$topics"
+    return 1
+  fi
+
+  if ! printf '%s\n' "$topics" | grep -qFx "$topic"
   then
     log "✅ topic $topic contains no records (topic does not exist)"
     return 0
@@ -418,7 +430,9 @@ function salesforce_assert_topic_empty() {
   then
     set -e
   fi
-  nb_messages="$(printf '%s\n' "$out" | tail -1)"
+  # Take the last purely-numeric line: stderr is merged in (deliberately, so it can be
+  # shown on failure) and a warning flushed after the count would otherwise be read as it.
+  nb_messages="$(printf '%s\n' "$out" | grep -oE '^[0-9]+$' | tail -1)"
 
   # The topic exists, so the count must be a number. Anything else means it could not be
   # determined - a failed docker exec, an unknown CP version, an empty awk sum - and must
@@ -468,10 +482,11 @@ function salesforce_connector_version() {
   fi
 
   # Trailing -SNAPSHOT is dropped so the result compares cleanly with a plain x.y.z bound.
-  # Accept any qualifier after x.y.z (-SNAPSHOT, -rc1, Maven timestamped snapshots,
-  # -jar-with-dependencies) and either case of the extension. version_gt strips the
-  # qualifier itself, so only the x.y.z prefix has to be recovered here.
-  echo "$artifact" | sed -nE 's/.*[-_]([0-9]+\.[0-9]+\.[0-9]+)([-.][^/]*)?\.([zZ][iI][pP]|[jJ][aA][rR])$/\1/p'
+  # The FIRST x.y.z triple is the Maven version; a greedy match would take the last, so
+  # ...-3.0.15-SNAPSHOT-cp-8.0.0.zip would resolve to 8.0.0. Any qualifier after it
+  # (-SNAPSHOT, -rc1, a timestamped snapshot, -jar-with-dependencies) is left to version_gt,
+  # which strips it.
+  echo "$artifact" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1
 }
 
 function salesforce_ensure_jwt_keystore() {

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -383,30 +383,49 @@ function salesforce_assert_topic_empty() {
   local topic="$1"
   local nb_messages=""
 
-  local out="" rc=0
-  out="$(playground topic get-number-records -t "$topic" 2>&1)"
-  rc=$?
-  nb_messages="$(printf '%s\n' "$out" | tail -1)"
+  local out="" rc=0 had_errexit=0
 
-  # Only an explicit "does not exist" may be read as "no errors were produced". Anything else
-  # non-numeric means the count could not be determined - a failed docker exec, an unknown CP
-  # version, an empty awk sum - and must fail rather than silently pass. logerror writes to
-  # stdout, so a discarded exit code plus 2>/dev/null would have turned those into a pass.
-  if [[ ! "$nb_messages" =~ ^[0-9]+$ ]]
+  # Callers run under `set -e`, so the count must be read with errexit off: otherwise a
+  # non-zero exit from the CLI kills the test script on this very line and none of the
+  # diagnostics below ever run.
+  case $- in
+    *e*) had_errexit=1 ;;
+  esac
+
+  # Decide existence directly instead of inferring it from a log line. Matching "does not
+  # exist" in the output was unsound in both directions: an empty or failed topic list is
+  # byte-identical to a genuinely absent topic (false pass), and the message is produced by
+  # logwarn, which returns early under PG_LOG_LEVEL=INFO (false failure).
+  set +e
+  playground get-topic-list | grep -qFx "$topic"
+  local topic_exists=$?
+  set -e
+  if [ $had_errexit -eq 0 ]
   then
-    if printf '%s' "$out" | grep -q "does not exist"
-    then
-      log "✅ topic $topic contains no records (topic was never created)"
-      return 0
-    fi
-    logerror "❌ could not determine the record count for $topic, refusing to assume it is empty"
-    printf '%s\n' "$out"
-    return 1
+    set +e
   fi
 
-  if [ $rc -ne 0 ]
+  if [ $topic_exists -ne 0 ]
   then
-    logerror "❌ getting the record count for $topic failed (rc=$rc)"
+    log "✅ topic $topic contains no records (topic does not exist)"
+    return 0
+  fi
+
+  set +e
+  out="$(playground topic get-number-records -t "$topic" 2>&1)"
+  rc=$?
+  if [ $had_errexit -eq 1 ]
+  then
+    set -e
+  fi
+  nb_messages="$(printf '%s\n' "$out" | tail -1)"
+
+  # The topic exists, so the count must be a number. Anything else means it could not be
+  # determined - a failed docker exec, an unknown CP version, an empty awk sum - and must
+  # fail rather than silently pass.
+  if [ $rc -ne 0 ] || [[ ! "$nb_messages" =~ ^[0-9]+$ ]]
+  then
+    logerror "❌ could not determine the record count for $topic (rc=$rc), refusing to assume it is empty"
     printf '%s\n' "$out"
     return 1
   fi
@@ -449,7 +468,10 @@ function salesforce_connector_version() {
   fi
 
   # Trailing -SNAPSHOT is dropped so the result compares cleanly with a plain x.y.z bound.
-  echo "$artifact" | sed -nE 's/.*[-_]([0-9]+\.[0-9]+\.[0-9]+)(-SNAPSHOT)?\.(zip|jar)$/\1/p'
+  # Accept any qualifier after x.y.z (-SNAPSHOT, -rc1, Maven timestamped snapshots,
+  # -jar-with-dependencies) and either case of the extension. version_gt strips the
+  # qualifier itself, so only the x.y.z prefix has to be recovered here.
+  echo "$artifact" | sed -nE 's/.*[-_]([0-9]+\.[0-9]+\.[0-9]+)([-.][^/]*)?\.([zZ][iI][pP]|[jJ][aA][rR])$/\1/p'
 }
 
 function salesforce_ensure_jwt_keystore() {

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -291,6 +291,49 @@ function salesforce_sfdx_with_retry() {
 
     SALESFORCE_CREATE_RETRIES_USED=$((SALESFORCE_CREATE_RETRIES_USED + 1))
     logwarn "⚠️ transient error during $label, retrying in ${delay}s (retry $SALESFORCE_CREATE_RETRIES_USED/$max_retries for this test)"
+
+    # A dead sfdx session cannot be fixed by re-running the command, so re-authenticate the
+    # org this command targets before retrying. Observed in CI on a PushTopic test: sfdx
+    # logged in successfully, then the very next `apex run` failed "Session expired or
+    # invalid" 4 seconds later, because an earlier username-password connector's validation
+    # logout() had killed the session Salesforce reuses for identical logins by the same user.
+    # Retrying alone would have burned the whole budget and still failed.
+    if echo "$out" | grep -qE "Session expired or invalid|INVALID_SESSION_ID|Bad_OAuth_Token"
+    then
+      case "$sfdx_command" in
+        *auth:login*)
+          # The command being retried IS a login; no point logging in first.
+          ;;
+        *)
+          local target=""
+          # First match only: a greedy .* would pick up a later --target-org appearing inside
+          # a SOQL string and re-authenticate the wrong org. Both long and short forms.
+          target="$(printf '%s' "$sfdx_command" \
+            | grep -oE '(--target-org|--targetusername|-o)[= ]+\\?"?[^"\\ ]+' \
+            | head -1 | sed -E 's/^(--target-org|--targetusername|-o)[= ]+\\?"?//')"
+          if [ -z "$target" ]
+          then
+            # Guessing the primary account here could refresh the wrong org's session, so
+            # say so and retry without re-authenticating rather than pick one.
+            logwarn "⚠️ could not determine the target org of $label, retrying without re-authenticating"
+          else
+            local suffix=""
+            if [ "$target" = "$SALESFORCE_USERNAME_ACCOUNT2" ]
+            then
+              suffix="_ACCOUNT2"
+            fi
+            # `if !` keeps errexit from killing the test when the re-login fails: this is a
+            # best-effort rescue, and the retry below is still worth attempting. Output is
+            # deliberately not suppressed so a failed re-login is visible in the CI log.
+            if ! salesforce_sfdx_relogin "$suffix"
+            then
+              logwarn "⚠️ re-authentication before retrying $label failed, retrying anyway"
+            fi
+          fi
+          ;;
+      esac
+    fi
+
     sleep "$delay"
     attempt=$((attempt + 1))
   done
@@ -321,8 +364,13 @@ function salesforce_sfdx_relogin() {
     return 1
   fi
 
-  log "🔑 Re-authenticating sfdx for $u before cleanup"
-  salesforce_sfdx_with_retry "sfdx sfpowerkit:auth:login -u \"$u\" -p \"$p\" -r \"$i\" -s \"$t\""
+  # Deliberately a single direct attempt, NOT routed through salesforce_sfdx_with_retry.
+  # Recursing would consume the shared per-test retry budget that the caller is trying to
+  # spend on the real step, and would sleep twice per attempt. Callers treat a failure here
+  # as best-effort.
+  log "🔑 Re-authenticating sfdx for $u"
+  playground container exec --container sfdx-cli \
+    --command "sfdx sfpowerkit:auth:login -u \"$u\" -p \"$p\" -r \"$i\" -s \"$t\"" --shell sh
 }
 
 # Assert a topic is empty, and fail the test if it is not.
@@ -335,13 +383,32 @@ function salesforce_assert_topic_empty() {
   local topic="$1"
   local nb_messages=""
 
-  nb_messages=$(playground topic get-number-records -t "$topic" 2>/dev/null | tail -1)
+  local out="" rc=0
+  out="$(playground topic get-number-records -t "$topic" 2>&1)"
+  rc=$?
+  nb_messages="$(printf '%s\n' "$out" | tail -1)"
 
-  # A topic that was never created means the connector produced no errors at all.
+  # Only an explicit "does not exist" may be read as "no errors were produced". Anything else
+  # non-numeric means the count could not be determined - a failed docker exec, an unknown CP
+  # version, an empty awk sum - and must fail rather than silently pass. logerror writes to
+  # stdout, so a discarded exit code plus 2>/dev/null would have turned those into a pass.
   if [[ ! "$nb_messages" =~ ^[0-9]+$ ]]
   then
-    log "✅ topic $topic contains no records (topic was never created)"
-    return 0
+    if printf '%s' "$out" | grep -q "does not exist"
+    then
+      log "✅ topic $topic contains no records (topic was never created)"
+      return 0
+    fi
+    logerror "❌ could not determine the record count for $topic, refusing to assume it is empty"
+    printf '%s\n' "$out"
+    return 1
+  fi
+
+  if [ $rc -ne 0 ]
+  then
+    logerror "❌ getting the record count for $topic failed (rc=$rc)"
+    printf '%s\n' "$out"
+    return 1
   fi
 
   if [ "$nb_messages" -gt 0 ]


### PR DESCRIPTION
Follow-up to #8749 and #8750. A review of the merged code found several defects, two of which let a test pass while verifying nothing — the bug class those PRs set out to remove. This fixes them and cuts the change set down.

## Defects fixed

**`salesforce_assert_topic_empty` could pass without checking anything.** `log`/`logerror` write to **stdout**, so `2>/dev/null` filtered nothing and the exit code was discarded: a hard failure inside `topic get-number-records` (`Could not find current CP version from docker ps`) or an empty `awk` sum arrived as a non-numeric value and returned success. Existence is now decided with `get-topic-list`, capturing the list and its status **separately** — piping into `grep` yields grep's status, which makes a failed or empty list indistinguishable from an absent topic. The count must then be numeric or the assertion fails.

**Six tests that CI runs created records with no cleanup at all.** #8749 removed the `stop.sh` Lead sweep on the grounds that "each test already removes exactly the records it created, in its own EXIT trap" — true of only **5 of the 13** data-creating tests. All 13 now have one, and the `stop.sh` comment says what is actually true.

**`restart_task_on_invalid_session` was gated on the password grant.** Despite its name it is also the only place these tests assert the task reached `RUNNING` — it fails with the task's stack trace on any other `FAILED` state. CI builds from the PR branch, so 3.0.0+ takes the JWT path and lost that assertion; a genuine task failure would have surfaced only as "topic contains 0 messages" with no trace. Now called for both grants.

**Cleanup could not retry, and failed silently.** The traps shared one per-test retry budget with the test body, so a test that spent its retries left cleanup with none, and in two-org tests the first delete could consume everything. Each org's delete now gets its own allowance, and a delete that ultimately fails warns instead of exiting 0 quietly.

**Retrying could not fix a dead sfdx session.** A connector on the username-password SOAP grant ends its session with a SOAP `logout()` during validation; Salesforce reuses one session across identical logins by the same user, so it also kills the session the sfdx CLI holds. Re-running a command cannot revive it. The retry helper now re-authenticates first. Observed in CI (job `7f1e9a52`): `salesforce-pushtopic-source.sh` logged in successfully at 17:30:03 and its next `apex run -f` failed `Session expired or invalid` at 17:30:10 — a **setup** step, before any connector existed and long before any trap could run.

**`salesforce_connector_version` was too narrow**, matching only `x.y.z[-SNAPSHOT]`, so an `-rc1` build, a Maven timestamped snapshot or a shaded jar silently fell back to the username-password grant and the JWT path was never exercised. It now takes the first `x.y.z` triple — the last would resolve `…-3.0.15-SNAPSHOT-cp-8.0.0.zip` to `8.0.0`.

## Smaller, not just fixed

A scope pass removed about a third of the original diff with no loss of behaviour:

- The 13 near-identical cleanup traps become calls to one `salesforce_cleanup_records` helper — **367 lines of copy-paste down to 150**. The duplication had already cost a real bug: `salesforce-cdc-source-proxy.sh` shipped a trap referencing two variables that file never set, invisible because it was copy 7 of 13.
- `restart_task_on_invalid_session` was defined verbatim in two test files; it moves to `utils.sh`.
- The six `data:query` verification calls are no longer retried. Their failure is already tolerated by `|| true` and the real assertion is the `grep` that follows, so retrying could not change the outcome — it only spent budget the EXIT trap needed moments later.
- `salesforce_sfdx_relogin` takes explicit credentials instead of an account suffix plus `${!var}` indirection, which bought nothing for two call shapes and enabled quoting artifacts that survived two review rounds.
- The three error-pattern lists are plain assignments; the `${VAR:-…}` overrides had no users, and overriding one would have silently dropped the `REQUEST_LIMIT_EXCEEDED` guard.

Also removes `salesforce-bulkapi-sink-with-bulkapi-source.sh` from `scripts/tests-ignored.txt`. It was disabled in `4c975607` with a commit message containing only the filename and no issue reference, so no reason is recorded; the timing matches the duplicate-Lead and `INVALID_SESSION_ID` flakiness since fixed in #8743, #8748, #8749 and #8750. It has now passed 13 consecutive local runs.

## Validation

21 runs, every CP version and connector branch the gate exercises, credentials from the same Vault path CI uses:

| Connector artifact | CP | Gated tests | Grant selected | Retries used |
|---|---|---|---|---|
| `2.0.41-SNAPSHOT` (2.0.x) | 7.9.0 | ✅ 7/7 | `PASSWORD` | 0 |
| `3.0.15-SNAPSHOT` (3.0.x) | 8.3.0 | ✅ 7/7 | `JWT_BEARER` | 0 |
| `3.1.9-SNAPSHOT` (3.1.x) | 8.3.0 | ✅ 7/7 | `JWT_BEARER` | 0 |

Zero cleanup warnings, and the cleanup re-authentication is visible in 5 logs per suite — the traps run rather than silently no-oping. Earlier rounds add CP 8.0.0 and 8.2.0 coverage on the same tests.

Helper logic is additionally covered by mocked assertions: errexit preserved from both `set -e` and `set +e` callers on every return path; fatal errors (`REQUEST_LIMIT_EXCEEDED`, `DUPLICATES_DETECTED`) never retried; the budget shared per test and never exceeded; a failing re-authentication warning rather than aborting the test; `--target-org` resolved to the correct org when a SOQL string mentions the other one.

## Note for maintainers

The `[ ! -z "$CONNECTOR_TAG" ] && ! version_gt $CONNECTOR_TAG …` guards in these tests are **silently dead** on `--connector-zip` / `--connector-jar` runs: `utils.sh` only assigns `CONNECTOR_TAG` on the path where neither is set, and CI gates build from the PR branch and pass `--connector-zip`. That is why `salesforce_connector_version` reads the version from the artifact filename instead. Roughly 18 such guards exist across the repo; they are left alone here rather than expand this PR's surface, but they are worth a look.
